### PR TITLE
use BIGINT not NUMERIC, it is faster for arithmetic operations and us…

### DIFF
--- a/db/migrations/00004_create_eth_header_cids_table.sql
+++ b/db/migrations/00004_create_eth_header_cids_table.sql
@@ -5,15 +5,15 @@ CREATE TABLE eth.header_cids (
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    td                    NUMERIC NOT NULL,
+    td                    BIGINT NOT NULL,
     node_id               VARCHAR(128) NOT NULL REFERENCES nodes (node_id) ON DELETE CASCADE,
-    reward                NUMERIC NOT NULL,
+    reward                BIGINT NOT NULL,
     state_root            VARCHAR(66) NOT NULL,
     tx_root               VARCHAR(66) NOT NULL,
     receipt_root          VARCHAR(66) NOT NULL,
     uncle_root            VARCHAR(66) NOT NULL,
     bloom                 BYTEA NOT NULL,
-    timestamp             NUMERIC NOT NULL,
+    timestamp             BIGINT NOT NULL,
     times_validated       INTEGER NOT NULL DEFAULT 1,
     base_fee              BIGINT
 );

--- a/db/migrations/00010_create_eth_state_accouts_table.sql
+++ b/db/migrations/00010_create_eth_state_accouts_table.sql
@@ -2,7 +2,7 @@
 CREATE TABLE eth.state_accounts (
     header_id             VARCHAR(66) NOT NULL,
     state_path            BYTEA NOT NULL,
-    balance               NUMERIC NOT NULL,
+    balance               BIGINT NOT NULL,
     nonce                 INTEGER NOT NULL,
     code_hash             BYTEA NOT NULL,
     storage_root          VARCHAR(66) NOT NULL,

--- a/db/pre_batch_processing_migrations/00004_create_eth_header_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00004_create_eth_header_cids_table.sql
@@ -5,15 +5,15 @@ CREATE TABLE eth.header_cids (
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     mh_key                TEXT NOT NULL,
-    td                    NUMERIC NOT NULL,
+    td                    BIGINT NOT NULL,
     node_id               VARCHAR(128) NOT NULL,
-    reward                NUMERIC NOT NULL,
+    reward                BIGINT NOT NULL,
     state_root            VARCHAR(66) NOT NULL,
     tx_root               VARCHAR(66) NOT NULL,
     receipt_root          VARCHAR(66) NOT NULL,
     uncle_root            VARCHAR(66) NOT NULL,
     bloom                 BYTEA NOT NULL,
-    timestamp             NUMERIC NOT NULL,
+    timestamp             BIGINT NOT NULL,
     times_validated       INTEGER NOT NULL DEFAULT 1,
     base_fee              BIGINT
 );

--- a/db/pre_batch_processing_migrations/00010_create_eth_state_accouts_table.sql
+++ b/db/pre_batch_processing_migrations/00010_create_eth_state_accouts_table.sql
@@ -2,7 +2,7 @@
 CREATE TABLE eth.state_accounts (
     header_id             VARCHAR(66) NOT NULL,
     state_path            BYTEA NOT NULL,
-    balance               NUMERIC NOT NULL,
+    balance               BIGINT NOT NULL,
     nonce                 INTEGER NOT NULL,
     code_hash             BYTEA NOT NULL,
     storage_root          VARCHAR(66) NOT NULL

--- a/schema.sql
+++ b/schema.sql
@@ -37,15 +37,15 @@ CREATE TABLE eth.header_cids (
     parent_hash character varying(66) NOT NULL,
     cid text NOT NULL,
     mh_key text NOT NULL,
-    td numeric NOT NULL,
+    td bigint NOT NULL,
     node_id character varying(128) NOT NULL,
-    reward numeric NOT NULL,
+    reward bigint NOT NULL,
     state_root character varying(66) NOT NULL,
     tx_root character varying(66) NOT NULL,
     receipt_root character varying(66) NOT NULL,
     uncle_root character varying(66) NOT NULL,
     bloom bytea NOT NULL,
-    "timestamp" numeric NOT NULL,
+    "timestamp" bigint NOT NULL,
     times_validated integer DEFAULT 1 NOT NULL,
     base_fee bigint
 );
@@ -265,7 +265,7 @@ CREATE TABLE eth.receipt_cids (
 CREATE TABLE eth.state_accounts (
     header_id character varying(66) NOT NULL,
     state_path bytea NOT NULL,
-    balance numeric NOT NULL,
+    balance bigint NOT NULL,
     nonce integer NOT NULL,
     code_hash bytea NOT NULL,
     storage_root character varying(66) NOT NULL


### PR DESCRIPTION
…es less space. Noticed while fixing issue with BaseFee big.Int not fitting in int64.