### PR TITLE
Schema updates

### DIFF
--- a/db/migrations/00002_create_nodes_table.sql
+++ b/db/migrations/00002_create_nodes_table.sql
@@ -1,9 +1,9 @@
 -- +goose Up
 CREATE TABLE nodes (
-  client_name   VARCHAR,
   genesis_block VARCHAR(66),
   network_id    VARCHAR,
   node_id       VARCHAR(128) PRIMARY KEY,
+  client_name   VARCHAR,
   chain_id      INTEGER DEFAULT 1
 );
 

--- a/db/migrations/00004_create_eth_header_cids_table.sql
+++ b/db/migrations/00004_create_eth_header_cids_table.sql
@@ -1,10 +1,9 @@
 -- +goose Up
 CREATE TABLE eth.header_cids (
-    block_hash            VARCHAR(66) PRIMARY KEY,
     block_number          BIGINT NOT NULL,
+    block_hash            VARCHAR(66) PRIMARY KEY,
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     td                    NUMERIC NOT NULL,
     node_id               VARCHAR(128) NOT NULL REFERENCES nodes (node_id) ON DELETE CASCADE,
     reward                NUMERIC NOT NULL,
@@ -14,8 +13,9 @@ CREATE TABLE eth.header_cids (
     uncle_root            VARCHAR(66) NOT NULL,
     bloom                 BYTEA NOT NULL,
     timestamp             BIGINT NOT NULL,
+    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     times_validated       INTEGER NOT NULL DEFAULT 1,
-    coinbase              VARCHAR(66) NOT NULL,
+    coinbase              VARCHAR(66) NOT NULL
 );
 
 -- +goose Down

--- a/db/migrations/00004_create_eth_header_cids_table.sql
+++ b/db/migrations/00004_create_eth_header_cids_table.sql
@@ -15,7 +15,7 @@ CREATE TABLE eth.header_cids (
     bloom                 BYTEA NOT NULL,
     timestamp             BIGINT NOT NULL,
     times_validated       INTEGER NOT NULL DEFAULT 1,
-    base_fee              NUMERIC
+    coinbase              VARCHAR(66) NOT NULL,
 );
 
 -- +goose Down

--- a/db/migrations/00005_create_eth_uncle_cids_table.sql
+++ b/db/migrations/00005_create_eth_uncle_cids_table.sql
@@ -4,8 +4,8 @@ CREATE TABLE eth.uncle_cids (
     header_id             VARCHAR(66) NOT NULL REFERENCES eth.header_cids (block_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    reward                NUMERIC NOT NULL
+    reward                NUMERIC NOT NULL,
+    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
 -- +goose Down

--- a/db/migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/migrations/00006_create_eth_transaction_cids_table.sql
@@ -8,7 +8,8 @@ CREATE TABLE eth.transaction_cids (
     dst                   VARCHAR(66) NOT NULL,
     src                   VARCHAR(66) NOT NULL,
     tx_data               BYTEA,
-    tx_type               INTEGER
+    tx_type               INTEGER,
+    value                 NUMERIC
 );
 
 -- +goose Down

--- a/db/migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/migrations/00006_create_eth_transaction_cids_table.sql
@@ -1,12 +1,12 @@
 -- +goose Up
 CREATE TABLE eth.transaction_cids (
-    tx_hash               VARCHAR(66) PRIMARY KEY,
     header_id             VARCHAR(66) NOT NULL REFERENCES eth.header_cids (block_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    index                 INTEGER NOT NULL,
+    tx_hash               VARCHAR(66) PRIMARY KEY,
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     dst                   VARCHAR(66) NOT NULL,
     src                   VARCHAR(66) NOT NULL,
+    index                 INTEGER NOT NULL,
+    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     tx_data               BYTEA,
     tx_type               INTEGER,
     value                 NUMERIC

--- a/db/migrations/00007_create_eth_receipt_cids_table.sql
+++ b/db/migrations/00007_create_eth_receipt_cids_table.sql
@@ -2,9 +2,9 @@
 CREATE TABLE eth.receipt_cids (
     tx_id                 VARCHAR(66) PRIMARY KEY REFERENCES eth.transaction_cids (tx_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     leaf_cid              TEXT NOT NULL,
-    leaf_mh_key           TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     contract              VARCHAR(66),
     contract_hash         VARCHAR(66),
+    leaf_mh_key           TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     post_state            VARCHAR(66),
     post_status           INTEGER,
     log_root              VARCHAR(66)

--- a/db/migrations/00008_create_eth_state_cids_table.sql
+++ b/db/migrations/00008_create_eth_state_cids_table.sql
@@ -3,10 +3,10 @@ CREATE TABLE eth.state_cids (
     header_id             VARCHAR(66) NOT NULL REFERENCES eth.header_cids (block_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     state_leaf_key        VARCHAR(66),
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     state_path            BYTEA NOT NULL,
     node_type             INTEGER NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
+    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     PRIMARY KEY (header_id, state_path)
 );
 

--- a/db/migrations/00009_create_eth_storage_cids_table.sql
+++ b/db/migrations/00009_create_eth_storage_cids_table.sql
@@ -4,10 +4,10 @@ CREATE TABLE eth.storage_cids (
     state_path            BYTEA NOT NULL,
     storage_leaf_key      VARCHAR(66),
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     storage_path          BYTEA NOT NULL,
     node_type             INTEGER NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
+    mh_key                TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     FOREIGN KEY (header_id, state_path) REFERENCES eth.state_cids (header_id, state_path) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     PRIMARY KEY (header_id, state_path, storage_path)
 );

--- a/db/migrations/00012_create_eth_log_cids_table.sql
+++ b/db/migrations/00012_create_eth_log_cids_table.sql
@@ -1,15 +1,15 @@
 -- +goose Up
 CREATE TABLE eth.log_cids (
-    rct_id              VARCHAR(66) NOT NULL REFERENCES eth.receipt_cids (tx_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     leaf_cid            TEXT NOT NULL,
     leaf_mh_key         TEXT NOT NULL REFERENCES public.blocks (key) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    rct_id              VARCHAR(66) NOT NULL REFERENCES eth.receipt_cids (tx_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     address             VARCHAR(66) NOT NULL,
-    log_data            BYTEA,
     index               INTEGER NOT NULL,
     topic0              VARCHAR(66),
     topic1              VARCHAR(66),
     topic2              VARCHAR(66),
     topic3              VARCHAR(66),
+    log_data            BYTEA,
     PRIMARY KEY (rct_id, index)
 );
 

--- a/db/pre_batch_processing_migrations/00002_create_nodes_table.sql
+++ b/db/pre_batch_processing_migrations/00002_create_nodes_table.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 CREATE TABLE nodes (
-  client_name   VARCHAR,
-  genesis_block VARCHAR(66),
-  network_id    VARCHAR,
-  node_id       VARCHAR(128) NOT NULL,
-  chain_id      INTEGER DEFAULT 1
+    genesis_block VARCHAR(66),
+    network_id    VARCHAR,
+    node_id       VARCHAR(128) NOT NULL,
+    client_name   VARCHAR,
+    chain_id      INTEGER DEFAULT 1
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00004_create_eth_header_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00004_create_eth_header_cids_table.sql
@@ -1,21 +1,21 @@
 -- +goose Up
 CREATE TABLE eth.header_cids (
-    block_hash            VARCHAR(66) NOT NULL,
-    block_number          BIGINT NOT NULL,
-    parent_hash           VARCHAR(66) NOT NULL,
-    cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL,
-    td                    NUMERIC NOT NULL,
-    node_id               VARCHAR(128) NOT NULL,
-    reward                NUMERIC NOT NULL,
-    state_root            VARCHAR(66) NOT NULL,
-    tx_root               VARCHAR(66) NOT NULL,
-    receipt_root          VARCHAR(66) NOT NULL,
-    uncle_root            VARCHAR(66) NOT NULL,
-    bloom                 BYTEA NOT NULL,
-    timestamp             BIGINT NOT NULL,
-    times_validated       INTEGER NOT NULL DEFAULT 1,
-    coinbase              VARCHAR(66) NOT NULL
+     block_number          BIGINT NOT NULL,
+     block_hash            VARCHAR(66) NOT NULL,
+     parent_hash           VARCHAR(66) NOT NULL,
+     cid                   TEXT NOT NULL,
+     td                    NUMERIC NOT NULL,
+     node_id               VARCHAR(128) NOT NULL,
+     reward                NUMERIC NOT NULL,
+     state_root            VARCHAR(66) NOT NULL,
+     tx_root               VARCHAR(66) NOT NULL,
+     receipt_root          VARCHAR(66) NOT NULL,
+     uncle_root            VARCHAR(66) NOT NULL,
+     bloom                 BYTEA NOT NULL,
+     timestamp             BIGINT NOT NULL,
+     mh_key                TEXT NOT NULL,
+     times_validated       INTEGER NOT NULL DEFAULT 1,
+     coinbase              VARCHAR(66) NOT NULL
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00004_create_eth_header_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00004_create_eth_header_cids_table.sql
@@ -15,7 +15,7 @@ CREATE TABLE eth.header_cids (
     bloom                 BYTEA NOT NULL,
     timestamp             BIGINT NOT NULL,
     times_validated       INTEGER NOT NULL DEFAULT 1,
-    base_fee              NUMERIC
+    coinbase              VARCHAR(66) NOT NULL
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00005_create_eth_uncle_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00005_create_eth_uncle_cids_table.sql
@@ -4,8 +4,8 @@ CREATE TABLE eth.uncle_cids (
     header_id             VARCHAR(66) NOT NULL,
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL,
-    reward                NUMERIC NOT NULL
+    reward                NUMERIC NOT NULL,
+    mh_key                TEXT NOT NULL
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00006_create_eth_transaction_cids_table.sql
@@ -1,12 +1,12 @@
 -- +goose Up
 CREATE TABLE eth.transaction_cids (
-    tx_hash               VARCHAR(66) NOT NULL,
     header_id             VARCHAR(66) NOT NULL,
-    index                 INTEGER NOT NULL,
+    tx_hash               VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL,
     dst                   VARCHAR(66) NOT NULL,
     src                   VARCHAR(66) NOT NULL,
+    index                 INTEGER NOT NULL,
+    mh_key                TEXT NOT NULL,
     tx_data               BYTEA,
     tx_type               INTEGER,
     value                 NUMERIC

--- a/db/pre_batch_processing_migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00006_create_eth_transaction_cids_table.sql
@@ -8,7 +8,8 @@ CREATE TABLE eth.transaction_cids (
     dst                   VARCHAR(66) NOT NULL,
     src                   VARCHAR(66) NOT NULL,
     tx_data               BYTEA,
-    tx_type               INTEGER
+    tx_type               INTEGER,
+    value                 NUMERIC
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00007_create_eth_receipt_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00007_create_eth_receipt_cids_table.sql
@@ -2,9 +2,9 @@
 CREATE TABLE eth.receipt_cids (
     tx_id                 VARCHAR(66) NOT NULL,
     leaf_cid              TEXT NOT NULL,
-    leaf_mh_key           TEXT NOT NULL,
     contract              VARCHAR(66),
     contract_hash         VARCHAR(66),
+    leaf_mh_key           TEXT NOT NULL,
     post_state            VARCHAR(66),
     post_status           INTEGER,
     log_root              VARCHAR(66)

--- a/db/pre_batch_processing_migrations/00008_create_eth_state_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00008_create_eth_state_cids_table.sql
@@ -3,10 +3,10 @@ CREATE TABLE eth.state_cids (
     header_id             VARCHAR(66) NOT NULL,
     state_leaf_key        VARCHAR(66),
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL,
     state_path            BYTEA NOT NULL,
     node_type             INTEGER NOT NULL,
-    diff                  BOOLEAN NOT NULL DEFAULT FALSE
+    diff                  BOOLEAN NOT NULL DEFAULT FALSE,
+    mh_key                TEXT NOT NULL
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00009_create_eth_storage_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00009_create_eth_storage_cids_table.sql
@@ -4,10 +4,10 @@ CREATE TABLE eth.storage_cids (
     state_path            BYTEA NOT NULL,
     storage_leaf_key      VARCHAR(66),
     cid                   TEXT NOT NULL,
-    mh_key                TEXT NOT NULL,
     storage_path          BYTEA NOT NULL,
     node_type             INTEGER NOT NULL,
-    diff                  BOOLEAN NOT NULL DEFAULT FALSE
+    diff                  BOOLEAN NOT NULL DEFAULT FALSE,
+    mh_key                TEXT NOT NULL
 );
 
 -- +goose Down

--- a/db/pre_batch_processing_migrations/00012_create_eth_log_cids_table.sql
+++ b/db/pre_batch_processing_migrations/00012_create_eth_log_cids_table.sql
@@ -1,15 +1,15 @@
 -- +goose Up
 CREATE TABLE eth.log_cids (
-    rct_id              VARCHAR(66) NOT NULL,
     leaf_cid            TEXT NOT NULL,
     leaf_mh_key         TEXT NOT NULL,
+    rct_id              VARCHAR(66) NOT NULL,
     address             VARCHAR(66) NOT NULL,
-    log_data            BYTEA,
     index               INTEGER NOT NULL,
     topic0              VARCHAR(66),
     topic1              VARCHAR(66),
     topic2              VARCHAR(66),
-    topic3              VARCHAR(66)
+    topic3              VARCHAR(66),
+    log_data            BYTEA
 );
 
 -- +goose Down

--- a/schema.sql
+++ b/schema.sql
@@ -32,11 +32,10 @@ SET default_table_access_method = heap;
 --
 
 CREATE TABLE eth.header_cids (
-    block_hash character varying(66) NOT NULL,
     block_number bigint NOT NULL,
+    block_hash character varying(66) NOT NULL,
     parent_hash character varying(66) NOT NULL,
     cid text NOT NULL,
-    mh_key text NOT NULL,
     td numeric NOT NULL,
     node_id character varying(128) NOT NULL,
     reward numeric NOT NULL,
@@ -46,8 +45,9 @@ CREATE TABLE eth.header_cids (
     uncle_root character varying(66) NOT NULL,
     bloom bytea NOT NULL,
     "timestamp" bigint NOT NULL,
+    mh_key text NOT NULL,
     times_validated integer DEFAULT 1 NOT NULL,
-    base_fee numeric
+    coinbase character varying(66) NOT NULL
 );
 
 
@@ -229,16 +229,16 @@ CREATE TABLE eth.access_list_elements (
 --
 
 CREATE TABLE eth.log_cids (
-    rct_id character varying(66) NOT NULL,
     leaf_cid text NOT NULL,
     leaf_mh_key text NOT NULL,
+    rct_id character varying(66) NOT NULL,
     address character varying(66) NOT NULL,
-    log_data bytea,
     index integer NOT NULL,
     topic0 character varying(66),
     topic1 character varying(66),
     topic2 character varying(66),
-    topic3 character varying(66)
+    topic3 character varying(66),
+    log_data bytea
 );
 
 
@@ -249,9 +249,9 @@ CREATE TABLE eth.log_cids (
 CREATE TABLE eth.receipt_cids (
     tx_id character varying(66) NOT NULL,
     leaf_cid text NOT NULL,
-    leaf_mh_key text NOT NULL,
     contract character varying(66),
     contract_hash character varying(66),
+    leaf_mh_key text NOT NULL,
     post_state character varying(66),
     post_status integer,
     log_root character varying(66)
@@ -280,10 +280,10 @@ CREATE TABLE eth.state_cids (
     header_id character varying(66) NOT NULL,
     state_leaf_key character varying(66),
     cid text NOT NULL,
-    mh_key text NOT NULL,
     state_path bytea NOT NULL,
     node_type integer NOT NULL,
-    diff boolean DEFAULT false NOT NULL
+    diff boolean DEFAULT false NOT NULL,
+    mh_key text NOT NULL
 );
 
 
@@ -296,10 +296,10 @@ CREATE TABLE eth.storage_cids (
     state_path bytea NOT NULL,
     storage_leaf_key character varying(66),
     cid text NOT NULL,
-    mh_key text NOT NULL,
     storage_path bytea NOT NULL,
     node_type integer NOT NULL,
-    diff boolean DEFAULT false NOT NULL
+    diff boolean DEFAULT false NOT NULL,
+    mh_key text NOT NULL
 );
 
 
@@ -308,15 +308,16 @@ CREATE TABLE eth.storage_cids (
 --
 
 CREATE TABLE eth.transaction_cids (
-    tx_hash character varying(66) NOT NULL,
     header_id character varying(66) NOT NULL,
-    index integer NOT NULL,
+    tx_hash character varying(66) NOT NULL,
     cid text NOT NULL,
-    mh_key text NOT NULL,
     dst character varying(66) NOT NULL,
     src character varying(66) NOT NULL,
+    index integer NOT NULL,
+    mh_key text NOT NULL,
     tx_data bytea,
-    tx_type integer
+    tx_type integer,
+    value numeric
 );
 
 
@@ -336,8 +337,8 @@ CREATE TABLE eth.uncle_cids (
     header_id character varying(66) NOT NULL,
     parent_hash character varying(66) NOT NULL,
     cid text NOT NULL,
-    mh_key text NOT NULL,
-    reward numeric NOT NULL
+    reward numeric NOT NULL,
+    mh_key text NOT NULL
 );
 
 
@@ -388,10 +389,10 @@ ALTER SEQUENCE public.goose_db_version_id_seq OWNED BY public.goose_db_version.i
 --
 
 CREATE TABLE public.nodes (
-    client_name character varying,
     genesis_block character varying(66),
     network_id character varying,
     node_id character varying(128) NOT NULL,
+    client_name character varying,
     chain_id integer DEFAULT 1
 );
 


### PR DESCRIPTION
Final schema review and refactor:

* Remove BaseFee from header_cids
* Add Coinbase to header_cids
* Add Value to transaction_cids
* Reorder columns for csv loading; reorder to match the statements here: https://github.com/vulcanize/go-ethereum/blob/postgres_refactor/statediff/indexer/database/file/writer.go#L120

I'm also wondering if we really need to store TxData and LogData blown out into transaction_cids and log_cids, respectively. I can imagine some instances where we would want to search on them but they also are the two largest fields of these types to duplicate.