### PR TITLE
Release v3.0.7

### DIFF
--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -17,8 +17,8 @@ CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
 CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 
 -- receipt indexes
-CREATE UNIQUE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
-CREATE UNIQUE INDEX rct_leaf_mh_index ON eth.receipt_cids USING btree (leaf_mh_key);
+CREATE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
+CREATE INDEX rct_leaf_mh_index ON eth.receipt_cids USING btree (leaf_mh_key);
 CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
 CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_hash);
 

--- a/db/post_batch_processing_migrations/00028_create_cid_indexes.sql
+++ b/db/post_batch_processing_migrations/00028_create_cid_indexes.sql
@@ -17,8 +17,8 @@ CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
 CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 
 -- receipt indexes
-CREATE UNIQUE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
-CREATE UNIQUE INDEX rct_leaf_mh_index ON eth.receipt_cids USING btree (leaf_mh_key);
+CREATE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
+CREATE INDEX rct_leaf_mh_index ON eth.receipt_cids USING btree (leaf_mh_key);
 CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
 CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_hash);
 

--- a/schema.sql
+++ b/schema.sql
@@ -626,14 +626,14 @@ CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number);
 -- Name: header_cid_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX header_cid_index ON eth.header_cids USING btree (cid);
+CREATE UNIQUE INDEX header_cid_index ON eth.header_cids USING btree (cid);
 
 
 --
 -- Name: header_mh_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX header_mh_index ON eth.header_cids USING btree (mh_key);
+CREATE UNIQUE INDEX header_mh_index ON eth.header_cids USING btree (mh_key);
 
 
 --
@@ -815,7 +815,7 @@ CREATE INDEX timestamp_index ON eth.header_cids USING brin ("timestamp");
 -- Name: tx_cid_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid);
+CREATE UNIQUE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid);
 
 
 --
@@ -836,7 +836,7 @@ CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
 -- Name: tx_mh_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX tx_mh_index ON eth.transaction_cids USING btree (mh_key);
+CREATE UNIQUE INDEX tx_mh_index ON eth.transaction_cids USING btree (mh_key);
 
 
 --


### PR DESCRIPTION
Minor fix for something that hasn't caused issue yet, but it is theoretically possible but quite improbable that two receipts (their consensus fields/encoding) are identical and so these indexes should not be unique indexes.