### PR TITLE
Fixes + new schema dump

### DIFF
--- a/db/migrations/00004_create_eth_header_cids_table.sql
+++ b/db/migrations/00004_create_eth_header_cids_table.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.header_cids (
     block_number          BIGINT NOT NULL,
-    block_hash            VARCHAR(66) PRIMARY KEY,
+    block_hash            VARCHAR(66) NOT NULL,
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     td                    NUMERIC NOT NULL,
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS eth.header_cids (
     mh_key                TEXT NOT NULL,
     times_validated       INTEGER NOT NULL DEFAULT 1,
     coinbase              VARCHAR(66) NOT NULL,
+    PRIMARY KEY (block_hash, block_number),
     FOREIGN KEY (mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 

--- a/db/migrations/00005_create_eth_uncle_cids_table.sql
+++ b/db/migrations/00005_create_eth_uncle_cids_table.sql
@@ -1,12 +1,14 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.uncle_cids (
     block_number          BIGINT NOT NULL,
-    block_hash            VARCHAR(66) PRIMARY KEY,
-    header_id             VARCHAR(66) NOT NULL REFERENCES eth.header_cids (block_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    block_hash            VARCHAR(66) NOT NULL,
+    header_id             VARCHAR(66) NOT NULL,
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     reward                NUMERIC NOT NULL,
     mh_key                TEXT NOT NULL,
+    PRIMARY KEY (block_hash, block_number),
+    FOREIGN KEY (header_id, block_number) REFERENCES eth.header_cids (block_hash, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     FOREIGN KEY (mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 

--- a/db/migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/migrations/00006_create_eth_transaction_cids_table.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.transaction_cids (
     block_number          BIGINT NOT NULL,
-    header_id             VARCHAR(66) NOT NULL REFERENCES eth.header_cids (block_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    tx_hash               VARCHAR(66) PRIMARY KEY,
+    header_id             VARCHAR(66) NOT NULL,
+    tx_hash               VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     dst                   VARCHAR(66) NOT NULL,
     src                   VARCHAR(66) NOT NULL,
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS eth.transaction_cids (
     tx_data               BYTEA,
     tx_type               INTEGER,
     value                 NUMERIC,
+    PRIMARY KEY (tx_hash, block_number),
+    FOREIGN KEY (header_id, block_number) REFERENCES eth.header_cids (block_hash, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     FOREIGN KEY (mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 

--- a/db/migrations/00007_create_eth_receipt_cids_table.sql
+++ b/db/migrations/00007_create_eth_receipt_cids_table.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.receipt_cids (
     block_number          BIGINT NOT NULL,
-    tx_id                 VARCHAR(66) PRIMARY KEY REFERENCES eth.transaction_cids (tx_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    tx_id                 VARCHAR(66) NOT NULL,
     leaf_cid              TEXT NOT NULL,
     contract              VARCHAR(66),
     contract_hash         VARCHAR(66),
@@ -9,6 +9,8 @@ CREATE TABLE IF NOT EXISTS eth.receipt_cids (
     post_state            VARCHAR(66),
     post_status           INTEGER,
     log_root              VARCHAR(66),
+    PRIMARY KEY (tx_id, block_number),
+    FOREIGN KEY (tx_id, block_number) REFERENCES eth.transaction_cids (tx_hash, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
     FOREIGN KEY (leaf_mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 

--- a/db/migrations/00008_create_eth_state_cids_table.sql
+++ b/db/migrations/00008_create_eth_state_cids_table.sql
@@ -1,15 +1,16 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.state_cids (
     block_number          BIGINT NOT NULL,
-    header_id             VARCHAR(66) NOT NULL REFERENCES eth.header_cids (block_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    header_id             VARCHAR(66) NOT NULL,
     state_leaf_key        VARCHAR(66),
     cid                   TEXT NOT NULL,
     state_path            BYTEA NOT NULL,
     node_type             INTEGER NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
     mh_key                TEXT NOT NULL,
-    FOREIGN KEY (mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    PRIMARY KEY (state_path, header_id)
+    PRIMARY KEY (state_path, header_id, block_number),
+    FOREIGN KEY (header_id, block_number) REFERENCES eth.header_cids (block_hash, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
 -- +goose Down

--- a/db/migrations/00009_create_eth_storage_cids_table.sql
+++ b/db/migrations/00009_create_eth_storage_cids_table.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS eth.storage_cids (
     block_number          BIGINT NOT NULL,
     header_id             VARCHAR(66) NOT NULL,
-    state_leaf_key            BYTEA NOT NULL,
+    state_path            BYTEA NOT NULL,
     storage_leaf_key      VARCHAR(66),
     cid                   TEXT NOT NULL,
     storage_path          BYTEA NOT NULL,
@@ -10,8 +10,8 @@ CREATE TABLE IF NOT EXISTS eth.storage_cids (
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
     mh_key                TEXT NOT NULL,
     FOREIGN KEY (mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    FOREIGN KEY (state_leaf_key, header_id) REFERENCES eth.state_cids (state_leaf_key, header_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    PRIMARY KEY (storage_path, state_leaf_key, header_id)
+    FOREIGN KEY (state_path, header_id, block_number) REFERENCES eth.state_cids (state_path, header_id, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    PRIMARY KEY (storage_path, state_path, header_id, block_number)
 );
 
 -- +goose Down

--- a/db/migrations/00010_create_eth_state_accounts_table.sql
+++ b/db/migrations/00010_create_eth_state_accounts_table.sql
@@ -7,8 +7,8 @@ CREATE TABLE IF NOT EXISTS eth.state_accounts (
     nonce                 BIGINT NOT NULL,
     code_hash             BYTEA NOT NULL,
     storage_root          VARCHAR(66) NOT NULL,
-    FOREIGN KEY (state_path, header_id) REFERENCES eth.state_cids (state_path, header_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    PRIMARY KEY (state_path, header_id)
+    PRIMARY KEY (state_path, header_id, block_number),
+    FOREIGN KEY (state_path, header_id, block_number) REFERENCES eth.state_cids (state_path, header_id, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
 -- +goose Down

--- a/db/migrations/00011_create_eth_access_list_elements_table.sql
+++ b/db/migrations/00011_create_eth_access_list_elements_table.sql
@@ -1,11 +1,12 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.access_list_elements (
     block_number          BIGINT NOT NULL,
-    tx_id                 VARCHAR(66) NOT NULL REFERENCES eth.transaction_cids (tx_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    tx_id                 VARCHAR(66) NOT NULL,
     index                 INTEGER NOT NULL,
     address               VARCHAR(66),
     storage_keys          VARCHAR(66)[],
-    PRIMARY KEY (tx_id, index)
+    PRIMARY KEY (tx_id, index, block_number),
+    FOREIGN KEY (tx_id, block_number) REFERENCES eth.transaction_cids (tx_hash, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
 -- +goose Down

--- a/db/migrations/00012_create_eth_log_cids_table.sql
+++ b/db/migrations/00012_create_eth_log_cids_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS eth.log_cids (
     block_number        BIGINT NOT NULL,
     leaf_cid            TEXT NOT NULL,
     leaf_mh_key         TEXT NOT NULL,
-    rct_id              VARCHAR(66) NOT NULL REFERENCES eth.receipt_cids (tx_id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    rct_id              VARCHAR(66) NOT NULL,
     address             VARCHAR(66) NOT NULL,
     index               INTEGER NOT NULL,
     topic0              VARCHAR(66),
@@ -11,8 +11,9 @@ CREATE TABLE IF NOT EXISTS eth.log_cids (
     topic2              VARCHAR(66),
     topic3              VARCHAR(66),
     log_data            BYTEA,
-    FOREIGN KEY (leaf_mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
-    PRIMARY KEY (rct_id, index)
+    PRIMARY KEY (rct_id, index, block_number),
+    FOREIGN KEY (rct_id, block_number) REFERENCES eth.receipt_cids (tx_id, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (leaf_mh_key, block_number) REFERENCES public.blocks (key, block_number) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
 -- +goose Down

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- header indexes
 CREATE INDEX header_block_number_index ON eth.header_cids USING brin (block_number);
-CREATE UNIQUE INDEX header_cid_index ON eth.header_cids USING btree (cid);
+CREATE UNIQUE INDEX header_cid_index ON eth.header_cids USING btree (cid, block_number);
 CREATE UNIQUE INDEX header_mh_block_number_index ON eth.header_cids USING btree (mh_key, block_number);
 CREATE INDEX state_root_index ON eth.header_cids USING btree (state_root);
 CREATE INDEX timestamp_index ON eth.header_cids USING brin (timestamp);
@@ -14,7 +14,7 @@ CREATE INDEX uncle_header_id_index ON eth.uncle_cids USING btree (header_id);
 -- transaction indexes
 CREATE INDEX tx_block_number_index ON eth.transaction_cids USING brin (block_number);
 CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
-CREATE UNIQUE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid);
+CREATE UNIQUE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
 CREATE UNIQUE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
 CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
 CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
@@ -36,7 +36,7 @@ CREATE INDEX state_node_type_index ON eth.state_cids USING btree (node_type);
 
 -- storage node indexes
 CREATE INDEX storage_block_number_index ON eth.storage_cids USING brin (block_number);
-CREATE INDEX storage_state_leaf_key_index ON eth.storage_cids USING btree (state_leaf_key);
+CREATE INDEX storage_state_path_index ON eth.storage_cids USING btree (state_path);
 CREATE INDEX storage_leaf_key_index ON eth.storage_cids USING btree (storage_leaf_key);
 CREATE INDEX storage_cid_index ON eth.storage_cids USING btree (cid);
 CREATE INDEX storage_mh_block_number_index ON eth.storage_cids USING btree (mh_key, block_number);
@@ -90,7 +90,7 @@ DROP INDEX eth.storage_header_id_index;
 DROP INDEX eth.storage_mh_block_number_index;
 DROP INDEX eth.storage_cid_index;
 DROP INDEX eth.storage_leaf_key_index;
-DROP INDEX eth.storage_state_leaf_key_index;
+DROP INDEX eth.storage_state_path_index;
 DROP INDEX eth.storage_block_number_index;
 
 -- state node indexes

--- a/db/migrations/00019_convert_to_hypertables.sql
+++ b/db/migrations/00019_convert_to_hypertables.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 SELECT create_hypertable('public.blocks', 'block_number', migrate_data => true, chunk_time_interval => 32768);
-SELECT create_hypertable('eth.header_cids', 'block_number' migrate_data => true, chunk_time_interval => 32768);
+SELECT create_hypertable('eth.header_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.uncle_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.transaction_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.receipt_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
@@ -32,15 +32,15 @@ CREATE TABLE public.blocks_i (LIKE public.blocks INCLUDING ALL);
 
 -- migrate data
 INSERT INTO eth.log_cids_i (SELECT * FROM eth.log_cids);
-INSERT INTO eth.access_list_elements_i (SELECT eth.access_list_elements);
-INSERT INTO eth.state_accounts_i (SELECT eth.state_accounts);
-INSERT INTO eth.storage_cids_i (SELECT eth.storage_cids);
-INSERT INTO eth.state_cids_i (SELECT eth.state_cids);
-INSERT INTO eth.receipt_cids_i (SELECT eth.receipt_cids);
-INSERT INTO eth.transaction_cids_i (SELECT eth.transaction_cids);
-INSERT INTO eth.uncle_cids_i (SELECT eth.uncle_cids);
-INSERT INTO eth.header_cids_i (SELECT eth.header_cids);
-INSERT INTO public.blocks_i (SELECT public.blocks);
+INSERT INTO eth.access_list_elements_i (SELECT * FROM eth.access_list_elements);
+INSERT INTO eth.state_accounts_i (SELECT * FROM eth.state_accounts);
+INSERT INTO eth.storage_cids_i (SELECT * FROM eth.storage_cids);
+INSERT INTO eth.state_cids_i (SELECT * FROM eth.state_cids);
+INSERT INTO eth.receipt_cids_i (SELECT * FROM eth.receipt_cids);
+INSERT INTO eth.transaction_cids_i (SELECT * FROM eth.transaction_cids);
+INSERT INTO eth.uncle_cids_i (SELECT * FROM eth.uncle_cids);
+INSERT INTO eth.header_cids_i (SELECT * FROM eth.header_cids);
+INSERT INTO public.blocks_i (SELECT * FROM public.blocks);
 
 -- drops hypertables
 DROP TABLE eth.log_cids;

--- a/db/migrations/00020_convert_to_distributed_hypertables.sql
+++ b/db/migrations/00020_convert_to_distributed_hypertables.sql
@@ -12,28 +12,28 @@ CREATE TABLE eth.header_cids_i (LIKE eth.header_cids INCLUDING ALL);
 CREATE TABLE public.blocks_i (LIKE public.blocks INCLUDING ALL);
 
 -- turn them into distributed hypertables
-SELECT create_distributed_hypertable('public.blocks_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.header_cids_i', 'block_number' migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.uncle_cids_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.transaction_cids_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.receipt_cids_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.state_cids_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.storage_cids_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.state_accounts_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.access_list_elements_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
-SELECT create_distributed_hypertable('eth.log_cids_i', 'block_number', migrate_data => true, chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('public.blocks_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.header_cids_i', 'block_number' chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.uncle_cids_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.transaction_cids_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.receipt_cids_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.state_cids_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.storage_cids_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.state_accounts_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.access_list_elements_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
+SELECT create_distributed_hypertable('eth.log_cids_i', 'block_number', chunk_time_interval => 32768, replication_factor => 3);
 
 -- migrate data
 INSERT INTO eth.log_cids_i (SELECT * FROM eth.log_cids);
-INSERT INTO eth.access_list_elements_i (SELECT eth.access_list_elements);
-INSERT INTO eth.state_accounts_i (SELECT eth.state_accounts);
-INSERT INTO eth.storage_cids_i (SELECT eth.storage_cids);
-INSERT INTO eth.state_cids_i (SELECT eth.state_cids);
-INSERT INTO eth.receipt_cids_i (SELECT eth.receipt_cids);
-INSERT INTO eth.transaction_cids_i (SELECT eth.transaction_cids);
-INSERT INTO eth.uncle_cids_i (SELECT eth.uncle_cids);
-INSERT INTO eth.header_cids_i (SELECT eth.header_cids);
-INSERT INTO public.blocks_i (SELECT public.blocks);
+INSERT INTO eth.access_list_elements_i (SELECT * FROM eth.access_list_elements);
+INSERT INTO eth.state_accounts_i (SELECT * FROM eth.state_accounts);
+INSERT INTO eth.storage_cids_i (SELECT * FROM eth.storage_cids);
+INSERT INTO eth.state_cids_i (SELECT * FROM eth.state_cids);
+INSERT INTO eth.receipt_cids_i (SELECT * FROM eth.receipt_cids);
+INSERT INTO eth.transaction_cids_i (SELECT * FROM eth.transaction_cids);
+INSERT INTO eth.uncle_cids_i (SELECT * FROM eth.uncle_cids);
+INSERT INTO eth.header_cids_i (SELECT * FROM eth.header_cids);
+INSERT INTO public.blocks_i (SELECT * FROM public.blocks);
 
 -- drops hypertables
 DROP TABLE eth.log_cids;
@@ -93,15 +93,15 @@ SELECT create_hypertable('eth.log_cids_i', 'block_number', migrate_data => true,
 
 -- migrate data
 INSERT INTO eth.log_cids_i (SELECT * FROM eth.log_cids);
-INSERT INTO eth.access_list_elements_i (SELECT eth.access_list_elements);
-INSERT INTO eth.state_accounts_i (SELECT eth.state_accounts);
-INSERT INTO eth.storage_cids_i (SELECT eth.storage_cids);
-INSERT INTO eth.state_cids_i (SELECT eth.state_cids);
-INSERT INTO eth.receipt_cids_i (SELECT eth.receipt_cids);
-INSERT INTO eth.transaction_cids_i (SELECT eth.transaction_cids);
-INSERT INTO eth.uncle_cids_i (SELECT eth.uncle_cids);
-INSERT INTO eth.header_cids_i (SELECT eth.header_cids);
-INSERT INTO public.blocks_i (SELECT public.blocks);
+INSERT INTO eth.access_list_elements_i (SELECT * FROM eth.access_list_elements);
+INSERT INTO eth.state_accounts_i (SELECT * FROM eth.state_accounts);
+INSERT INTO eth.storage_cids_i (SELECT * FROM eth.storage_cids);
+INSERT INTO eth.state_cids_i (SELECT * FROM eth.state_cids);
+INSERT INTO eth.receipt_cids_i (SELECT * FROM eth.receipt_cids);
+INSERT INTO eth.transaction_cids_i (SELECT * FROM eth.transaction_cids);
+INSERT INTO eth.uncle_cids_i (SELECT * FROM eth.uncle_cids);
+INSERT INTO eth.header_cids_i (SELECT * FROM eth.header_cids);
+INSERT INTO public.blocks_i (SELECT * FROM public.blocks);
 
 -- drops distributed hypertables
 DROP TABLE eth.log_cids;


### PR DESCRIPTION
The schema dump doesn't include the distributed hypertables as they can only be created *after* enough data nodes have been added to support the specified replication factor. Data nodes will be specific to an instance of an access server, so this would break generality of the schema.


The main fix introduced here is to extend the denormalization to all primary keys