### PR TITLE
Update instructions and docker-compose files for simplified db setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ WORKDIR /app
 
 COPY --from=builder /go/src/github.com/vulcanize/ipld-eth-db/scripts/startup_script.sh .
 
-# copy over file for TimescaleDB setup
-COPY --from=builder /go/src/github.com/vulcanize/ipld-eth-db/docker-compose.test.yml docker-tsdb/docker-compose.test.yml
-
 COPY --from=builder /go/src/github.com/pressly/goose/cmd/goose/goose goose
 COPY --from=builder /go/src/github.com/vulcanize/ipld-eth-db/db/migrations migrations/vulcanizedb
 

--- a/README.md
+++ b/README.md
@@ -12,28 +12,24 @@ Schemas and utils for IPLD ETH Postgres database
   docker-compose down -v --remove-orphans
   ```
 
-* Spin up a TimescaleDB instance using [docker-compose.test.yml](./docker-compose.test.yml):
+* Spin up `ipld-eth-db` using an existing image:
 
-  ```bash
-  docker-compose -f docker-compose.test.yml up
-  ```
+  * Update image source used for running the migrations in [docker-compose.yml](./docker-compose.yml) (if required).
 
-  Following final output should be seen:
+  * Run:
 
     ```
-    LOG:  TimescaleDB background worker launcher connected to shared catalogs
+    docker-compose -f docker-compose.yml up
     ```
 
-* In another `ipld-eth-db` terminal window, build an image `migrations-test` using [Dockerfile](./db/Dockerfile):
+* Spin up `ipld-eth-db` using a locally built image:
 
-  ```bash
-  docker build -t migrations-test -f ./db/Dockerfile .
-  ```
+  * Update [Dockerfile](./Dockerfile) (if required).
 
-* Start a container using `migrations-test` image to run the db migrations:
+  * Update build context used for running the migrations in [docker-compose.test.yml](./docker-compose.test.yml) (if required).
 
-  ```bash
-  # Here, we are running the container using host network.
-  # So connect to TimescaleDB on 127.0.0.1:8066
-  docker run --rm --network host -e DATABASE_USER=vdbm -e DATABASE_PASSWORD=password -e DATABASE_HOSTNAME=127.0.0.1 -e DATABASE_PORT=8066 -e DATABASE_NAME=vulcanize_testing_v4 migrations-test
-  ```
+  * Run:
+
+    ```
+    docker-compose -f docker-compose.test.yml up
+    ```

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,14 +1,28 @@
 version: '3.2'
 
 services:
-  access-node:
+  migrations:
+    restart: on-failure
+    depends_on:
+      - ipld-eth-db
+    # Build image using local context
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_USER: "vdbm"
+      DATABASE_NAME: "vulcanize_testing"
+      DATABASE_PASSWORD: "password"
+      DATABASE_HOSTNAME: "ipld-eth-db"
+      DATABASE_PORT: 5432
+
+  ipld-eth-db:
     image: timescale/timescaledb:latest-pg14
     restart: always
-    container_name: access-node
     command: ["postgres", "-c", "log_statement=all"]
     environment:
       POSTGRES_USER: "vdbm"
-      POSTGRES_DB: "vulcanize_testing_v4"
+      POSTGRES_DB: "vulcanize_testing"
       POSTGRES_PASSWORD: "password"
     ports:
-      - "127.0.0.1:8066:5432"
+      - "127.0.0.1:8077:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,26 @@
 version: '3.2'
 
 services:
+  migrations:
+    restart: on-failure
+    depends_on:
+      - ipld-eth-db
+    # Use an existing image
+    image: vulcanize/ipld-eth-db:v4.1.1-alpha
+    environment:
+      DATABASE_USER: "vdbm"
+      DATABASE_NAME: "vulcanize_testing"
+      DATABASE_PASSWORD: "password"
+      DATABASE_HOSTNAME: "ipld-eth-db"
+      DATABASE_PORT: 5432
+
   ipld-eth-db:
+    image: timescale/timescaledb:latest-pg14
     restart: always
-    image: vulcanize/ipld-eth-db
-    build: .
+    command: ["postgres", "-c", "log_statement=all"]
     environment:
       POSTGRES_USER: "vdbm"
       POSTGRES_DB: "vulcanize_testing"
       POSTGRES_PASSWORD: "password"
-      hostname: db
     ports:
       - "127.0.0.1:8077:5432"


### PR DESCRIPTION
Part of https://github.com/vulcanize/ipld-eth-db/issues/68

- Simplified approach for creating single-node TimescaleDB setup
- Updated README
- Made changes to the docker-compose files to setup the db using either an existing or a locally built image