### PR TITLE
Add block hash to primary keys in transactions, receipts and logs tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.vscode

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Schemas and utils for IPLD ETH Postgres database
   * Run:
 
     ```
-    docker-compose -f docker-compose.test.yml up
+    docker-compose -f docker-compose.test.yml up --build
     ```

--- a/db/migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/migrations/00006_create_eth_transaction_cids_table.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS eth.transaction_cids (
     tx_data               BYTEA,
     tx_type               INTEGER,
     value                 NUMERIC,
-    PRIMARY KEY (tx_hash, block_number)
+    PRIMARY KEY (tx_hash, header_id, block_number)
 );
 
 -- +goose Down

--- a/db/migrations/00007_create_eth_receipt_cids_table.sql
+++ b/db/migrations/00007_create_eth_receipt_cids_table.sql
@@ -1,6 +1,7 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.receipt_cids (
     block_number          BIGINT NOT NULL,
+    header_id             VARCHAR(66) NOT NULL,
     tx_id                 VARCHAR(66) NOT NULL,
     leaf_cid              TEXT NOT NULL,
     contract              VARCHAR(66),
@@ -9,7 +10,7 @@ CREATE TABLE IF NOT EXISTS eth.receipt_cids (
     post_state            VARCHAR(66),
     post_status           INTEGER,
     log_root              VARCHAR(66),
-    PRIMARY KEY (tx_id, block_number)
+    PRIMARY KEY (tx_id, header_id, block_number)
 );
 
 -- +goose Down

--- a/db/migrations/00012_create_eth_log_cids_table.sql
+++ b/db/migrations/00012_create_eth_log_cids_table.sql
@@ -1,6 +1,7 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS eth.log_cids (
     block_number        BIGINT NOT NULL,
+    header_id           VARCHAR(66) NOT NULL,
     leaf_cid            TEXT NOT NULL,
     leaf_mh_key         TEXT NOT NULL,
     rct_id              VARCHAR(66) NOT NULL,
@@ -11,7 +12,7 @@ CREATE TABLE IF NOT EXISTS eth.log_cids (
     topic2              VARCHAR(66),
     topic3              VARCHAR(66),
     log_data            BYTEA,
-    PRIMARY KEY (rct_id, index, block_number)
+    PRIMARY KEY (rct_id, index, header_id, block_number)
 );
 
 -- +goose Down

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -21,6 +21,7 @@ CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 
 -- receipt indexes
 CREATE INDEX rct_block_number_index ON eth.receipt_cids USING brin (block_number);
+CREATE INDEX rct_header_id_index ON eth.receipt_cids USING btree (header_id);
 CREATE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
 CREATE INDEX rct_leaf_mh_block_number_index ON eth.receipt_cids USING btree (leaf_mh_key, block_number);
 CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
@@ -55,6 +56,7 @@ CREATE INDEX access_list_storage_keys_index ON eth.access_list_elements USING gi
 
 -- log indexes
 CREATE INDEX log_block_number_index ON eth.log_cids USING brin (block_number);
+CREATE INDEX log_header_id_index ON eth.log_cids USING btree (header_id);
 CREATE INDEX log_leaf_mh_block_number_index ON eth.log_cids USING btree (leaf_mh_key, block_number);
 CREATE INDEX log_cid_index ON  eth.log_cids USING btree (leaf_cid);
 CREATE INDEX log_address_index ON eth.log_cids USING btree (address);
@@ -72,6 +74,7 @@ DROP INDEX eth.log_topic0_index;
 DROP INDEX eth.log_address_index;
 DROP INDEX eth.log_cid_index;
 DROP INDEX eth.log_leaf_mh_block_number_index;
+DROP INDEX eth.log_header_id_index;
 DROP INDEX eth.log_block_number_index;
 
 -- access list indexes
@@ -106,6 +109,7 @@ DROP INDEX eth.rct_contract_hash_index;
 DROP INDEX eth.rct_contract_index;
 DROP INDEX eth.rct_leaf_mh_block_number_index;
 DROP INDEX eth.rct_leaf_cid_index;
+DROP INDEX eth.rct_header_id_index;
 DROP INDEX eth.rct_block_number_index;
 
 -- transaction indexes

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -14,8 +14,8 @@ CREATE INDEX uncle_header_id_index ON eth.uncle_cids USING btree (header_id);
 -- transaction indexes
 CREATE INDEX tx_block_number_index ON eth.transaction_cids USING brin (block_number);
 CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
-CREATE UNIQUE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
-CREATE UNIQUE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
+CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
+CREATE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
 CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
 CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 

--- a/db/migrations/00015_create_postgraphile_triggers.sql
+++ b/db/migrations/00015_create_postgraphile_triggers.sql
@@ -22,17 +22,20 @@ BEGIN
     ELSIF (TG_TABLE_NAME = 'log_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
+                    NEW.header_id,
                     NEW.rct_id,
                     NEW.index
                 );
     ELSIF (TG_TABLE_NAME = 'receipt_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
+                    NEW.header_id,
                     NEW.tx_id
                 );
     ELSIF (TG_TABLE_NAME = 'transaction_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
+                    NEW.header_id,
                     NEW.tx_hash
                 );
     ELSIF (TG_TABLE_NAME = 'access_list_elements') THEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - ipld-eth-db
     # Use an existing image
-    image: vulcanize/ipld-eth-db:v4.1.1-alpha
+    image: vulcanize/ipld-eth-db:v4.1.4-alpha
     environment:
       DATABASE_USER: "vdbm"
       DATABASE_NAME: "vulcanize_testing"


### PR DESCRIPTION
Part of https://github.com/vulcanize/ipld-eth-db/issues/99

- Add block hash (`header_id`) field to `receipt_cids` and `log_cids` tables
- Add block hash to the primary keys and postgraphile triggers on `transaction_cids`, `receipt_cids` and `log_cids` tables
- Add indexes on `receipt_cids` and `log_cids` tables using `header_id`
- Make indexes on using `cid` and `mh_key` on `transaction_cids` non-unique