### PR TITLE
Add new indexes and functions to improve eth_getStorageAt performance.

### DIFF
--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -34,6 +34,7 @@ CREATE INDEX state_cid_index ON eth.state_cids USING btree (cid);
 CREATE INDEX state_mh_block_number_index ON eth.state_cids USING btree (mh_key, block_number);
 CREATE INDEX state_header_id_index ON eth.state_cids USING btree (header_id);
 CREATE INDEX state_node_type_index ON eth.state_cids USING btree (node_type);
+CREATE INDEX state_leaf_key_block_number_index ON eth.state_cids(state_leaf_key, block_number DESC);
 
 -- storage node indexes
 CREATE INDEX storage_block_number_index ON eth.storage_cids USING brin (block_number);
@@ -43,6 +44,7 @@ CREATE INDEX storage_cid_index ON eth.storage_cids USING btree (cid);
 CREATE INDEX storage_mh_block_number_index ON eth.storage_cids USING btree (mh_key, block_number);
 CREATE INDEX storage_header_id_index ON eth.storage_cids USING btree (header_id);
 CREATE INDEX storage_node_type_index ON eth.storage_cids USING btree (node_type);
+CREATE INDEX storage_leaf_key_block_number_index ON eth.storage_cids(storage_leaf_key, block_number DESC);
 
 -- state accounts indexes
 CREATE INDEX account_block_number_index ON eth.state_accounts USING brin (block_number);
@@ -95,6 +97,7 @@ DROP INDEX eth.storage_cid_index;
 DROP INDEX eth.storage_leaf_key_index;
 DROP INDEX eth.storage_state_path_index;
 DROP INDEX eth.storage_block_number_index;
+DROP INDEX eth.storage_leaf_key_block_number_index;
 
 -- state node indexes
 DROP INDEX eth.state_node_type_index;
@@ -103,6 +106,7 @@ DROP INDEX eth.state_mh_block_number_index;
 DROP INDEX eth.state_cid_index;
 DROP INDEX eth.state_leaf_key_index;
 DROP INDEX eth.state_block_number_index;
+DROP INDEX eth.state_leaf_key_block_number_index;
 
 -- receipt indexes
 DROP INDEX eth.rct_contract_hash_index;

--- a/db/migrations/00023_get_storage_at_functions.sql
+++ b/db/migrations/00023_get_storage_at_functions.sql
@@ -53,6 +53,9 @@ DECLARE
     blockNo bigint;
 BEGIN
     SELECT h.BLOCK_NUMBER INTO blockNo FROM ETH.HEADER_CIDS as h WHERE BLOCK_HASH = blockHash limit 1;
+    IF blockNo IS NULL THEN
+        RETURN;
+    END IF;
     RETURN QUERY SELECT * FROM get_storage_at_by_number(stateLeafKey, storageLeafKey, blockNo);
 END
 $$;

--- a/db/migrations/00023_get_storage_at_functions.sql
+++ b/db/migrations/00023_get_storage_at_functions.sql
@@ -1,0 +1,66 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION was_state_leaf_removed_by_number(key character varying, blockNo bigint)
+    RETURNS boolean AS $$
+SELECT state_cids.node_type = 3
+FROM eth.state_cids
+         INNER JOIN eth.header_cids ON (state_cids.header_id = header_cids.block_hash)
+WHERE state_leaf_key = key
+  AND state_cids.block_number <= blockNo
+ORDER BY state_cids.block_number DESC LIMIT 1;
+$$
+language sql;
+
+CREATE OR REPLACE FUNCTION get_storage_at_by_number(stateLeafKey text, storageLeafKey text, blockNo bigint)
+    RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed bool) LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY SELECT STORAGE_CIDS.CID,
+                        STORAGE_CIDS.MH_KEY,
+                        STORAGE_CIDS.BLOCK_NUMBER,
+                        STORAGE_CIDS.NODE_TYPE,
+                        was_state_leaf_removed_by_number(
+                                stateLeafKey,
+                                blockNo
+                            ) AS STATE_LEAF_REMOVED
+                 FROM ETH.STORAGE_CIDS
+                          INNER JOIN ETH.STATE_CIDS ON (
+                             STORAGE_CIDS.HEADER_ID = STATE_CIDS.HEADER_ID
+                         AND STORAGE_CIDS.BLOCK_NUMBER = STATE_CIDS.BLOCK_NUMBER
+                         AND STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH
+                         AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
+                     )
+                          INNER JOIN ETH.HEADER_CIDS ON (
+                             STATE_CIDS.HEADER_ID = HEADER_CIDS.BLOCK_HASH
+                         AND STATE_CIDS.BLOCK_NUMBER = HEADER_CIDS.BLOCK_NUMBER
+                         AND STATE_CIDS.BLOCK_NUMBER <= blockNo
+                     )
+                 WHERE STATE_LEAF_KEY = stateLeafKey
+                   AND STATE_CIDS.BLOCK_NUMBER <= blockNo
+                   AND STORAGE_LEAF_KEY = storageLeafKey
+                   AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
+                   AND HEADER_CIDS.BLOCK_NUMBER <= blockNo
+                   AND HEADER_CIDS.BLOCK_HASH = (SELECT CANONICAL_HEADER_HASH(HEADER_CIDS.BLOCK_NUMBER))
+                 ORDER BY HEADER_CIDS.BLOCK_NUMBER DESC
+                 LIMIT 1;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION get_storage_at_by_hash(stateLeafKey text, storageLeafKey text, blockHash text)
+    RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed bool) LANGUAGE plpgsql
+AS $$
+DECLARE
+    blockNo bigint;
+BEGIN
+    SELECT h.BLOCK_NUMBER INTO blockNo FROM ETH.HEADER_CIDS as h WHERE BLOCK_HASH = blockHash limit 1;
+    RETURN QUERY SELECT * FROM get_storage_at_by_number(stateLeafKey, storageLeafKey, blockNo);
+END
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP FUNCTION was_state_leaf_removed_by_number;
+DROP FUNCTION get_storage_at_by_number;
+DROP FUNCTION get_storage_at_by_hash;
+-- +goose StatementEnd

--- a/db/migrations/00023_get_storage_at_functions.sql
+++ b/db/migrations/00023_get_storage_at_functions.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE OR REPLACE FUNCTION was_state_leaf_removed_by_number(key character varying, blockNo bigint)
+CREATE OR REPLACE FUNCTION public.was_state_leaf_removed_by_number(key character varying, blockNo bigint)
     RETURNS boolean AS $$
 SELECT state_cids.node_type = 3
 FROM eth.state_cids
@@ -11,7 +11,7 @@ ORDER BY state_cids.block_number DESC LIMIT 1;
 $$
 language sql;
 
-CREATE OR REPLACE FUNCTION get_storage_at_by_number(stateLeafKey text, storageLeafKey text, blockNo bigint)
+CREATE OR REPLACE FUNCTION public.get_storage_at_by_number(stateLeafKey text, storageLeafKey text, blockNo bigint)
     RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed bool) LANGUAGE plpgsql
 AS $$
 BEGIN
@@ -46,7 +46,7 @@ BEGIN
 END
 $$;
 
-CREATE OR REPLACE FUNCTION get_storage_at_by_hash(stateLeafKey text, storageLeafKey text, blockHash text)
+CREATE OR REPLACE FUNCTION public.get_storage_at_by_hash(stateLeafKey text, storageLeafKey text, blockHash text)
     RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed bool) LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -63,7 +63,7 @@ $$;
 
 -- +goose Down
 -- +goose StatementBegin
-DROP FUNCTION was_state_leaf_removed_by_number;
-DROP FUNCTION get_storage_at_by_number;
-DROP FUNCTION get_storage_at_by_hash;
+DROP FUNCTION public.was_state_leaf_removed_by_number;
+DROP FUNCTION public.get_storage_at_by_number;
+DROP FUNCTION public.get_storage_at_by_hash;
 -- +goose StatementEnd

--- a/schema.sql
+++ b/schema.sql
@@ -151,17 +151,20 @@ BEGIN
     ELSIF (TG_TABLE_NAME = 'log_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
+                    NEW.header_id,
                     NEW.rct_id,
                     NEW.index
                 );
     ELSIF (TG_TABLE_NAME = 'receipt_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
+                    NEW.header_id,
                     NEW.tx_id
                 );
     ELSIF (TG_TABLE_NAME = 'transaction_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
+                    NEW.header_id,
                     NEW.tx_hash
                 );
     ELSIF (TG_TABLE_NAME = 'access_list_elements') THEN
@@ -272,6 +275,65 @@ $$;
 
 
 --
+-- Name: get_storage_at_by_hash(text, text, text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_storage_at_by_hash(stateleafkey text, storageleafkey text, blockhash text) RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed boolean)
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    blockNo bigint;
+BEGIN
+    SELECT h.BLOCK_NUMBER INTO blockNo FROM ETH.HEADER_CIDS as h WHERE BLOCK_HASH = blockHash limit 1;
+    IF blockNo IS NULL THEN
+        RETURN;
+    END IF;
+    RETURN QUERY SELECT * FROM get_storage_at_by_number(stateLeafKey, storageLeafKey, blockNo);
+END
+$$;
+
+
+--
+-- Name: get_storage_at_by_number(text, text, bigint); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.get_storage_at_by_number(stateleafkey text, storageleafkey text, blockno bigint) RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed boolean)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN QUERY SELECT STORAGE_CIDS.CID,
+                        STORAGE_CIDS.MH_KEY,
+                        STORAGE_CIDS.BLOCK_NUMBER,
+                        STORAGE_CIDS.NODE_TYPE,
+                        was_state_leaf_removed_by_number(
+                                stateLeafKey,
+                                blockNo
+                            ) AS STATE_LEAF_REMOVED
+                 FROM ETH.STORAGE_CIDS
+                          INNER JOIN ETH.STATE_CIDS ON (
+                             STORAGE_CIDS.HEADER_ID = STATE_CIDS.HEADER_ID
+                         AND STORAGE_CIDS.BLOCK_NUMBER = STATE_CIDS.BLOCK_NUMBER
+                         AND STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH
+                         AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
+                     )
+                          INNER JOIN ETH.HEADER_CIDS ON (
+                             STATE_CIDS.HEADER_ID = HEADER_CIDS.BLOCK_HASH
+                         AND STATE_CIDS.BLOCK_NUMBER = HEADER_CIDS.BLOCK_NUMBER
+                         AND STATE_CIDS.BLOCK_NUMBER <= blockNo
+                     )
+                 WHERE STATE_LEAF_KEY = stateLeafKey
+                   AND STATE_CIDS.BLOCK_NUMBER <= blockNo
+                   AND STORAGE_LEAF_KEY = storageLeafKey
+                   AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
+                   AND HEADER_CIDS.BLOCK_NUMBER <= blockNo
+                   AND HEADER_CIDS.BLOCK_HASH = (SELECT CANONICAL_HEADER_HASH(HEADER_CIDS.BLOCK_NUMBER))
+                 ORDER BY HEADER_CIDS.BLOCK_NUMBER DESC
+                 LIMIT 1;
+END
+$$;
+
+
+--
 -- Name: has_child(character varying, bigint); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -321,24 +383,24 @@ BEGIN
         RAISE EXCEPTION 'cannot create state snapshot, no header can be found at height %', ending_height;
     END IF;
     -- select all of the state nodes for this snapshot: the latest state node record at every unique path
-    SELECT DISTINCT ON (state_path) blocks.data, state_cids.state_leaf_key, state_cids.cid, state_cids.state_path,
-        state_cids.node_type, state_cids.mh_key
-    INTO results
+    SELECT ARRAY (SELECT DISTINCT ON (state_path) ROW (blocks.data, state_cids.state_leaf_key, state_cids.cid, state_cids.state_path,
+        state_cids.node_type, state_cids.mh_key)
     FROM eth.state_cids
         INNER JOIN public.blocks
             ON (state_cids.mh_key, state_cids.block_number) = (blocks.key, blocks.block_number)
     WHERE state_cids.block_number BETWEEN starting_height AND ending_height
-    ORDER BY state_path, block_number DESC;
+    ORDER BY state_path, state_cids.block_number DESC)
+    INTO results;
     -- from the set returned above, insert public.block records at the ending_height block number
     INSERT INTO public.blocks (block_number, key, data)
     SELECT ending_height, r.mh_key, r.data
-    FROM results r;
+    FROM unnest(results) r;
     -- from the set returned above, insert eth.state_cids records at the ending_height block number
     -- anchoring all the records to the canonical header found at ending_height
     INSERT INTO eth.state_cids (block_number, header_id, state_leaf_key, cid, state_path, node_type, diff, mh_key)
     SELECT ending_height, canonical_hash, r.state_leaf_key, r.cid, r.state_path, r.node_type, false, r.mh_key
-    FROM results r
-    ON CONFLICT (state_path, header_id) DO NOTHING;
+    FROM unnest(results) r
+    ON CONFLICT (state_path, header_id, block_number) DO NOTHING;
 END
 $$;
 
@@ -360,27 +422,27 @@ BEGIN
         RAISE EXCEPTION 'cannot create state snapshot, no header can be found at height %', ending_height;
     END IF;
     -- select all of the storage nodes for this snapshot: the latest storage node record at every unique state leaf key
-    SELECT DISTINCT ON (state_leaf_key, storage_path) block.data, storage_cids.state_path, storage_cids.storage_leaf_key,
-     storage_cids.cid, storage_cids.storage_path, storage_cids.node_type, storage_cids.mh_key
-    INTO results
+    SELECT ARRAY (SELECT DISTINCT ON (state_leaf_key, storage_path) ROW (blocks.data, storage_cids.state_path, storage_cids.storage_leaf_key,
+     storage_cids.cid, storage_cids.storage_path, storage_cids.node_type, storage_cids.mh_key)
     FROM eth.storage_cids
         INNER JOIN public.blocks
         ON (storage_cids.mh_key, storage_cids.block_number) = (blocks.key, blocks.block_number)
         INNER JOIN eth.state_cids
         ON (storage_cids.state_path, storage_cids.header_id) = (state_cids.state_path, state_cids.header_id)
     WHERE storage_cids.block_number BETWEEN starting_height AND ending_height
-    ORDER BY state_path, storage_path, block_number DESC;
+    ORDER BY state_leaf_key, storage_path, storage_cids.state_path, storage_cids.block_number DESC)
+    INTO results;
     -- from the set returned above, insert public.block records at the ending_height block number
     INSERT INTO public.blocks (block_number, key, data)
     SELECT ending_height, r.mh_key, r.data
-    FROM results r;
+    FROM unnest(results) r;
     -- from the set returned above, insert eth.state_cids records at the ending_height block number
     -- anchoring all the records to the canonical header found at ending_height
     INSERT INTO eth.storage_cids (block_number, header_id, state_path, storage_leaf_key, cid, storage_path,
                               node_type, diff, mh_key)
     SELECT ending_height, canonical_hash, r.state_path, r.storage_leaf_key, r.cid, r.storage_path, r.node_type, false, r.mh_key
-    FROM results r
-    ON CONFLICT (storage_path, state_path, header_id) DO NOTHING;
+    FROM unnest(results) r
+    ON CONFLICT (storage_path, state_path, header_id, block_number) DO NOTHING;
 END
 $$;
 
@@ -404,6 +466,22 @@ $$;
 
 
 --
+-- Name: was_state_leaf_removed_by_number(character varying, bigint); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.was_state_leaf_removed_by_number(key character varying, blockno bigint) RETURNS boolean
+    LANGUAGE sql
+    AS $$
+SELECT state_cids.node_type = 3
+FROM eth.state_cids
+         INNER JOIN eth.header_cids ON (state_cids.header_id = header_cids.block_hash)
+WHERE state_leaf_key = key
+  AND state_cids.block_number <= blockNo
+ORDER BY state_cids.block_number DESC LIMIT 1;
+$$;
+
+
+--
 -- Name: access_list_elements; Type: TABLE; Schema: eth; Owner: -
 --
 
@@ -422,6 +500,7 @@ CREATE TABLE eth.access_list_elements (
 
 CREATE TABLE eth.log_cids (
     block_number bigint NOT NULL,
+    header_id character varying(66) NOT NULL,
     leaf_cid text NOT NULL,
     leaf_mh_key text NOT NULL,
     rct_id character varying(66) NOT NULL,
@@ -441,6 +520,7 @@ CREATE TABLE eth.log_cids (
 
 CREATE TABLE eth.receipt_cids (
     block_number bigint NOT NULL,
+    header_id character varying(66) NOT NULL,
     tx_id character varying(66) NOT NULL,
     leaf_cid text NOT NULL,
     contract character varying(66),
@@ -675,7 +755,7 @@ ALTER TABLE ONLY eth.header_cids
 --
 
 ALTER TABLE ONLY eth.log_cids
-    ADD CONSTRAINT log_cids_pkey PRIMARY KEY (rct_id, index, block_number);
+    ADD CONSTRAINT log_cids_pkey PRIMARY KEY (rct_id, index, header_id, block_number);
 
 
 --
@@ -683,7 +763,7 @@ ALTER TABLE ONLY eth.log_cids
 --
 
 ALTER TABLE ONLY eth.receipt_cids
-    ADD CONSTRAINT receipt_cids_pkey PRIMARY KEY (tx_id, block_number);
+    ADD CONSTRAINT receipt_cids_pkey PRIMARY KEY (tx_id, header_id, block_number);
 
 
 --
@@ -715,7 +795,7 @@ ALTER TABLE ONLY eth.storage_cids
 --
 
 ALTER TABLE ONLY eth.transaction_cids
-    ADD CONSTRAINT transaction_cids_pkey PRIMARY KEY (tx_hash, block_number);
+    ADD CONSTRAINT transaction_cids_pkey PRIMARY KEY (tx_hash, header_id, block_number);
 
 
 --
@@ -859,6 +939,13 @@ CREATE INDEX log_cid_index ON eth.log_cids USING btree (leaf_cid);
 
 
 --
+-- Name: log_header_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX log_header_id_index ON eth.log_cids USING btree (header_id);
+
+
+--
 -- Name: log_leaf_mh_block_number_index; Type: INDEX; Schema: eth; Owner: -
 --
 
@@ -915,6 +1002,13 @@ CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
 
 
 --
+-- Name: rct_header_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_header_id_index ON eth.receipt_cids USING btree (header_id);
+
+
+--
 -- Name: rct_leaf_cid_index; Type: INDEX; Schema: eth; Owner: -
 --
 
@@ -947,6 +1041,13 @@ CREATE INDEX state_cid_index ON eth.state_cids USING btree (cid);
 --
 
 CREATE INDEX state_header_id_index ON eth.state_cids USING btree (header_id);
+
+
+--
+-- Name: state_leaf_key_block_number_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_leaf_key_block_number_index ON eth.state_cids USING btree (state_leaf_key, block_number DESC);
 
 
 --
@@ -999,6 +1100,13 @@ CREATE INDEX storage_header_id_index ON eth.storage_cids USING btree (header_id)
 
 
 --
+-- Name: storage_leaf_key_block_number_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_leaf_key_block_number_index ON eth.storage_cids USING btree (storage_leaf_key, block_number DESC);
+
+
+--
 -- Name: storage_leaf_key_index; Type: INDEX; Schema: eth; Owner: -
 --
 
@@ -1044,7 +1152,7 @@ CREATE INDEX tx_block_number_index ON eth.transaction_cids USING brin (block_num
 -- Name: tx_cid_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE UNIQUE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
+CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
 
 
 --
@@ -1065,7 +1173,7 @@ CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
 -- Name: tx_mh_block_number_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE UNIQUE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
+CREATE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
 
 
 --

--- a/schema.sql
+++ b/schema.sql
@@ -151,20 +151,17 @@ BEGIN
     ELSIF (TG_TABLE_NAME = 'log_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
-                    NEW.header_id,
                     NEW.rct_id,
                     NEW.index
                 );
     ELSIF (TG_TABLE_NAME = 'receipt_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
-                    NEW.header_id,
                     NEW.tx_id
                 );
     ELSIF (TG_TABLE_NAME = 'transaction_cids') THEN
          obj := json_build_array(
                     TG_TABLE_NAME,
-                    NEW.header_id,
                     NEW.tx_hash
                 );
     ELSIF (TG_TABLE_NAME = 'access_list_elements') THEN
@@ -275,62 +272,6 @@ $$;
 
 
 --
--- Name: get_storage_at_by_hash(text, text, text); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.get_storage_at_by_hash(stateleafkey text, storageleafkey text, blockhash text) RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed boolean)
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    blockNo bigint;
-BEGIN
-    SELECT h.BLOCK_NUMBER INTO blockNo FROM ETH.HEADER_CIDS as h WHERE BLOCK_HASH = blockHash limit 1;
-    RETURN QUERY SELECT * FROM get_storage_at_by_number(stateLeafKey, storageLeafKey, blockNo);
-END
-$$;
-
-
---
--- Name: get_storage_at_by_number(text, text, bigint); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.get_storage_at_by_number(stateleafkey text, storageleafkey text, blockno bigint) RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed boolean)
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    RETURN QUERY SELECT STORAGE_CIDS.CID,
-                        STORAGE_CIDS.MH_KEY,
-                        STORAGE_CIDS.BLOCK_NUMBER,
-                        STORAGE_CIDS.NODE_TYPE,
-                        was_state_leaf_removed_by_number(
-                                stateLeafKey,
-                                blockNo
-                            ) AS STATE_LEAF_REMOVED
-                 FROM ETH.STORAGE_CIDS
-                          INNER JOIN ETH.STATE_CIDS ON (
-                             STORAGE_CIDS.HEADER_ID = STATE_CIDS.HEADER_ID
-                         AND STORAGE_CIDS.BLOCK_NUMBER = STATE_CIDS.BLOCK_NUMBER
-                         AND STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH
-                         AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
-                     )
-                          INNER JOIN ETH.HEADER_CIDS ON (
-                             STATE_CIDS.HEADER_ID = HEADER_CIDS.BLOCK_HASH
-                         AND STATE_CIDS.BLOCK_NUMBER = HEADER_CIDS.BLOCK_NUMBER
-                         AND STATE_CIDS.BLOCK_NUMBER <= blockNo
-                     )
-                 WHERE STATE_LEAF_KEY = stateLeafKey
-                   AND STATE_CIDS.BLOCK_NUMBER <= blockNo
-                   AND STORAGE_LEAF_KEY = storageLeafKey
-                   AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
-                   AND HEADER_CIDS.BLOCK_NUMBER <= blockNo
-                   AND HEADER_CIDS.BLOCK_HASH = (SELECT CANONICAL_HEADER_HASH(HEADER_CIDS.BLOCK_NUMBER))
-                 ORDER BY HEADER_CIDS.BLOCK_NUMBER DESC
-                 LIMIT 1;
-END
-$$;
-
-
---
 -- Name: has_child(character varying, bigint); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -380,24 +321,24 @@ BEGIN
         RAISE EXCEPTION 'cannot create state snapshot, no header can be found at height %', ending_height;
     END IF;
     -- select all of the state nodes for this snapshot: the latest state node record at every unique path
-    SELECT ARRAY (SELECT DISTINCT ON (state_path) ROW (blocks.data, state_cids.state_leaf_key, state_cids.cid, state_cids.state_path,
-        state_cids.node_type, state_cids.mh_key)
+    SELECT DISTINCT ON (state_path) blocks.data, state_cids.state_leaf_key, state_cids.cid, state_cids.state_path,
+        state_cids.node_type, state_cids.mh_key
+    INTO results
     FROM eth.state_cids
         INNER JOIN public.blocks
             ON (state_cids.mh_key, state_cids.block_number) = (blocks.key, blocks.block_number)
     WHERE state_cids.block_number BETWEEN starting_height AND ending_height
-    ORDER BY state_path, state_cids.block_number DESC)
-    INTO results;
+    ORDER BY state_path, block_number DESC;
     -- from the set returned above, insert public.block records at the ending_height block number
     INSERT INTO public.blocks (block_number, key, data)
     SELECT ending_height, r.mh_key, r.data
-    FROM unnest(results) r;
+    FROM results r;
     -- from the set returned above, insert eth.state_cids records at the ending_height block number
     -- anchoring all the records to the canonical header found at ending_height
     INSERT INTO eth.state_cids (block_number, header_id, state_leaf_key, cid, state_path, node_type, diff, mh_key)
     SELECT ending_height, canonical_hash, r.state_leaf_key, r.cid, r.state_path, r.node_type, false, r.mh_key
-    FROM unnest(results) r
-    ON CONFLICT (state_path, header_id, block_number) DO NOTHING;
+    FROM results r
+    ON CONFLICT (state_path, header_id) DO NOTHING;
 END
 $$;
 
@@ -419,27 +360,27 @@ BEGIN
         RAISE EXCEPTION 'cannot create state snapshot, no header can be found at height %', ending_height;
     END IF;
     -- select all of the storage nodes for this snapshot: the latest storage node record at every unique state leaf key
-    SELECT ARRAY (SELECT DISTINCT ON (state_leaf_key, storage_path) ROW (blocks.data, storage_cids.state_path, storage_cids.storage_leaf_key,
-     storage_cids.cid, storage_cids.storage_path, storage_cids.node_type, storage_cids.mh_key)
+    SELECT DISTINCT ON (state_leaf_key, storage_path) block.data, storage_cids.state_path, storage_cids.storage_leaf_key,
+     storage_cids.cid, storage_cids.storage_path, storage_cids.node_type, storage_cids.mh_key
+    INTO results
     FROM eth.storage_cids
         INNER JOIN public.blocks
         ON (storage_cids.mh_key, storage_cids.block_number) = (blocks.key, blocks.block_number)
         INNER JOIN eth.state_cids
         ON (storage_cids.state_path, storage_cids.header_id) = (state_cids.state_path, state_cids.header_id)
     WHERE storage_cids.block_number BETWEEN starting_height AND ending_height
-    ORDER BY state_leaf_key, storage_path, storage_cids.state_path, storage_cids.block_number DESC)
-    INTO results;
+    ORDER BY state_path, storage_path, block_number DESC;
     -- from the set returned above, insert public.block records at the ending_height block number
     INSERT INTO public.blocks (block_number, key, data)
     SELECT ending_height, r.mh_key, r.data
-    FROM unnest(results) r;
+    FROM results r;
     -- from the set returned above, insert eth.state_cids records at the ending_height block number
     -- anchoring all the records to the canonical header found at ending_height
     INSERT INTO eth.storage_cids (block_number, header_id, state_path, storage_leaf_key, cid, storage_path,
                               node_type, diff, mh_key)
     SELECT ending_height, canonical_hash, r.state_path, r.storage_leaf_key, r.cid, r.storage_path, r.node_type, false, r.mh_key
-    FROM unnest(results) r
-    ON CONFLICT (storage_path, state_path, header_id, block_number) DO NOTHING;
+    FROM results r
+    ON CONFLICT (storage_path, state_path, header_id) DO NOTHING;
 END
 $$;
 
@@ -463,22 +404,6 @@ $$;
 
 
 --
--- Name: was_state_leaf_removed_by_number(character varying, bigint); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.was_state_leaf_removed_by_number(key character varying, blockno bigint) RETURNS boolean
-    LANGUAGE sql
-    AS $$
-SELECT state_cids.node_type = 3
-FROM eth.state_cids
-         INNER JOIN eth.header_cids ON (state_cids.header_id = header_cids.block_hash)
-WHERE state_leaf_key = key
-  AND state_cids.block_number <= blockNo
-ORDER BY state_cids.block_number DESC LIMIT 1;
-$$;
-
-
---
 -- Name: access_list_elements; Type: TABLE; Schema: eth; Owner: -
 --
 
@@ -497,7 +422,6 @@ CREATE TABLE eth.access_list_elements (
 
 CREATE TABLE eth.log_cids (
     block_number bigint NOT NULL,
-    header_id character varying(66) NOT NULL,
     leaf_cid text NOT NULL,
     leaf_mh_key text NOT NULL,
     rct_id character varying(66) NOT NULL,
@@ -517,7 +441,6 @@ CREATE TABLE eth.log_cids (
 
 CREATE TABLE eth.receipt_cids (
     block_number bigint NOT NULL,
-    header_id character varying(66) NOT NULL,
     tx_id character varying(66) NOT NULL,
     leaf_cid text NOT NULL,
     contract character varying(66),
@@ -752,7 +675,7 @@ ALTER TABLE ONLY eth.header_cids
 --
 
 ALTER TABLE ONLY eth.log_cids
-    ADD CONSTRAINT log_cids_pkey PRIMARY KEY (rct_id, index, header_id, block_number);
+    ADD CONSTRAINT log_cids_pkey PRIMARY KEY (rct_id, index, block_number);
 
 
 --
@@ -760,7 +683,7 @@ ALTER TABLE ONLY eth.log_cids
 --
 
 ALTER TABLE ONLY eth.receipt_cids
-    ADD CONSTRAINT receipt_cids_pkey PRIMARY KEY (tx_id, header_id, block_number);
+    ADD CONSTRAINT receipt_cids_pkey PRIMARY KEY (tx_id, block_number);
 
 
 --
@@ -792,7 +715,7 @@ ALTER TABLE ONLY eth.storage_cids
 --
 
 ALTER TABLE ONLY eth.transaction_cids
-    ADD CONSTRAINT transaction_cids_pkey PRIMARY KEY (tx_hash, header_id, block_number);
+    ADD CONSTRAINT transaction_cids_pkey PRIMARY KEY (tx_hash, block_number);
 
 
 --
@@ -936,13 +859,6 @@ CREATE INDEX log_cid_index ON eth.log_cids USING btree (leaf_cid);
 
 
 --
--- Name: log_header_id_index; Type: INDEX; Schema: eth; Owner: -
---
-
-CREATE INDEX log_header_id_index ON eth.log_cids USING btree (header_id);
-
-
---
 -- Name: log_leaf_mh_block_number_index; Type: INDEX; Schema: eth; Owner: -
 --
 
@@ -996,13 +912,6 @@ CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_h
 --
 
 CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
-
-
---
--- Name: rct_header_id_index; Type: INDEX; Schema: eth; Owner: -
---
-
-CREATE INDEX rct_header_id_index ON eth.receipt_cids USING btree (header_id);
 
 
 --
@@ -1135,7 +1044,7 @@ CREATE INDEX tx_block_number_index ON eth.transaction_cids USING brin (block_num
 -- Name: tx_cid_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
+CREATE UNIQUE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
 
 
 --
@@ -1156,7 +1065,7 @@ CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
 -- Name: tx_mh_block_number_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
+CREATE UNIQUE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
 
 
 --


### PR DESCRIPTION
As mentioned in https://github.com/cerc-io/ipld-eth-server/issues/200, retrieving a value by state_leaf_key, storage_leaf_key, and block_hash is very slow.

That example query took over 153 seconds.  The biggest contributor was the lack of a proper btree index on leaf key and block number.  The chunks of the hypertable are partitioned by block_number, and without this compound index, each chunk will need to be checked (104 each in `state_cids` and `storage_cids`).  With it, we can start with the most likely chunk, and even no exact match for the key+block is found, because of the ordering of the index we will obtain the nearest candidate at similar cost.

After adding the two (leaf_key, block_number) indexes, the time drops to ~17s; significantly faster, but still too slow for general use.

```
 Planning Time: 102.504 ms
 Execution Time: 16509.402 ms
```

Part of the issue is that obtaining the block_number in a subquery like this

```
HEADER_CIDS.BLOCK_NUMBER <=
		(SELECT BLOCK_NUMBER
			FROM ETH.HEADER_CIDS
			WHERE BLOCK_HASH = '0xf11b57c121457ef927263acd7ae88729acf99f6e1a856cefc85e55ef9e4fd977')
```
means that the query planner cannot figure out the target the candidate chunks in the planning stage and has to walk through the chunks regardless.  While still ultimately aided by the new indexes, this still has the secondary effect of collecting a much larger number of potential rows for use in the JOIN, and calling `CANONICAL_HEADER_HASH` on each.

By separating out the steps inside a function, we can obtain the starting block number from the block hash first, and by sprinkling it across the query wherever it is relevant, allow the query planner to narrow down the scope significantly.

A small additional optimization is to create a version of `was_state_leaf_removed` which takes the block number as an argument, to avoid calling re-executing the subquery `SELECT block_number FROM eth.header_cids WHERE block_hash = hash`.

The combined result is shows around 250ms "cold" and 40ms "hot":

```
explain analyze select * from get_storage_at_by_hash('0xf9dc898f06b597cae6fb275f3b035d48254bd3d2cb929be172580914e9e4d94d', '0x8a35acfbc15ff81a39ae7d344fd709f28e8600b4aa8c65c6b64bfe7fe36bd19b', '0xf11b57c121457ef927263acd7ae88729acf99f6e1a856cefc85e55ef9e4fd977');
                                                          QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------
 Function Scan on get_storage_at_by_hash  (cost=0.25..10.25 rows=1000 width=77) (actual time=231.628..231.628 rows=1 loops=1)
 Planning Time: 0.083 ms
 Execution Time: 232.638 ms

###############################

explain analyze select * from get_storage_at_by_hash('0xf9dc898f06b597cae6fb275f3b035d48254bd3d2cb929be172580914e9e4d94d', '0x8a35acfbc15ff81a39ae7d344fd709f28e8600b4aa8c65c6b64bfe7fe36bd19b', '0xf11b57c121457ef927263acd7ae88729acf99f6e1a856cefc85e55ef9e4fd977');
                                                         QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------
 Function Scan on get_storage_at_by_hash  (cost=0.25..10.25 rows=1000 width=77) (actual time=41.295..41.296 rows=1 loops=1)
 Planning Time: 0.038 ms
 Execution Time: 38.982 ms
```