### PR TITLE
Draft: Split get_storage_at into two paths: one optimistic and simple, the other more comprehensive but slower.

### DIFF
--- a/db/migrations/00023_get_storage_at_functions.sql
+++ b/db/migrations/00023_get_storage_at_functions.sql
@@ -73,12 +73,12 @@ BEGIN
     into temp_header, temp_canonical_header, blockNo
     from tmp_tt_stg2;
     IF temp_header IS NOT NULL AND temp_header != temp_canonical_header THEN
-        raise notice 'get_storage_at_by_number (% is NULL OR % != %), falling back to full check.', temp_header, temp_header, temp_canonical_header;
+        raise notice 'get_storage_at_by_number: chosen header % != canonical header % for block number %, trying again.', temp_header, temp_canonical_header, blockNo;
         TRUNCATE tmp_tt_stg2;
-        -- There is a slim chance of a false negative, if there is a common state_path at a lower height than we picked above,
-        -- or a different one at the same height.  The disadvantage is that this is very uncommon, and the join on
-        -- STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH is quite expensive when there are a lot of candidate rows,
-        -- so we wish to avoid this more expensive check when possible.
+        -- If we chose a non-canonical block, we need to go back and get the right one.  While we could do this in one
+        -- query if we wanted, the disadvantage would be that it is very uncommon, while the join on
+        -- STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH is quite expensive whenever there are a lot of candidate rows,
+        -- so we wish to avoid that more expensive check when possible.
         INSERT INTO tmp_tt_stg2
         SELECT STORAGE_CIDS.HEADER_ID,
                STORAGE_CIDS.CID,

--- a/db/migrations/00023_get_storage_at_functions.sql
+++ b/db/migrations/00023_get_storage_at_functions.sql
@@ -12,37 +12,105 @@ $$
 language sql;
 
 CREATE OR REPLACE FUNCTION public.get_storage_at_by_number(stateLeafKey text, storageLeafKey text, blockNo bigint)
-    RETURNS TABLE(cid text, mh_key text, block_number bigint, node_type integer, state_leaf_removed bool) LANGUAGE plpgsql
-AS $$
+    RETURNS TABLE
+            (
+                cid                text,
+                mh_key             text,
+                block_number       bigint,
+                node_type          integer,
+                state_leaf_removed bool
+            )
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    statePath             bytea;
+    temp_header           text;
+    temp_canonical_header text;
 BEGIN
-    RETURN QUERY SELECT STORAGE_CIDS.CID,
-                        STORAGE_CIDS.MH_KEY,
-                        STORAGE_CIDS.BLOCK_NUMBER,
-                        STORAGE_CIDS.NODE_TYPE,
-                        was_state_leaf_removed_by_number(
-                                stateLeafKey,
-                                blockNo
-                            ) AS STATE_LEAF_REMOVED
-                 FROM ETH.STORAGE_CIDS
-                          INNER JOIN ETH.STATE_CIDS ON (
-                             STORAGE_CIDS.HEADER_ID = STATE_CIDS.HEADER_ID
-                         AND STORAGE_CIDS.BLOCK_NUMBER = STATE_CIDS.BLOCK_NUMBER
-                         AND STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH
-                         AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
-                     )
-                          INNER JOIN ETH.HEADER_CIDS ON (
-                             STATE_CIDS.HEADER_ID = HEADER_CIDS.BLOCK_HASH
-                         AND STATE_CIDS.BLOCK_NUMBER = HEADER_CIDS.BLOCK_NUMBER
-                         AND STATE_CIDS.BLOCK_NUMBER <= blockNo
-                     )
-                 WHERE STATE_LEAF_KEY = stateLeafKey
-                   AND STATE_CIDS.BLOCK_NUMBER <= blockNo
-                   AND STORAGE_LEAF_KEY = storageLeafKey
-                   AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
-                   AND HEADER_CIDS.BLOCK_NUMBER <= blockNo
-                   AND HEADER_CIDS.BLOCK_HASH = (SELECT CANONICAL_HEADER_HASH(HEADER_CIDS.BLOCK_NUMBER))
-                 ORDER BY HEADER_CIDS.BLOCK_NUMBER DESC
-                 LIMIT 1;
+    CREATE TEMP TABLE tmp_tt_stg2
+    (
+        header_id          text,
+        cid                text,
+        mh_key             text,
+        block_number       bigint,
+        node_type          integer,
+        state_leaf_removed bool
+    ) ON COMMIT DROP;
+
+    SELECT state_path, STATE_CIDS.block_number
+    INTO statePath, blockNo
+    FROM ETH.STATE_CIDS
+    WHERE STATE_LEAF_KEY = stateLeafKey
+      AND STATE_CIDS.BLOCK_NUMBER <= blockNo
+    ORDER BY STATE_CIDS.BLOCK_NUMBER DESC
+    LIMIT 1;
+
+    INSERT INTO tmp_tt_stg2
+    SELECT STORAGE_CIDS.HEADER_ID,
+           STORAGE_CIDS.CID,
+           STORAGE_CIDS.MH_KEY,
+           STORAGE_CIDS.BLOCK_NUMBER,
+           STORAGE_CIDS.NODE_TYPE,
+           was_state_leaf_removed_by_number(
+                   stateLeafKey,
+                   blockNo
+               ) AS STATE_LEAF_REMOVED
+    FROM eth.storage_cids
+             INNER JOIN ETH.STATE_CIDS ON (
+                STORAGE_CIDS.HEADER_ID = STATE_CIDS.HEADER_ID
+            AND STORAGE_CIDS.BLOCK_NUMBER = STATE_CIDS.BLOCK_NUMBER
+        )
+    WHERE storage_leaf_key = storageLeafKey
+      AND storage_cids.block_number <= blockNo
+      AND storage_cids.state_path = statePath
+      AND state_leaf_key = stateLeafKey
+      AND storage_cids.block_number <= blockNo
+    ORDER BY state_cids.block_number DESC
+    LIMIT 1;
+
+    SELECT header_id, canonical_header_hash(tmp_tt_stg2.block_number)
+    into temp_header, temp_canonical_header
+    from tmp_tt_stg2;
+    IF temp_header IS NULL OR temp_header != temp_canonical_header THEN
+        raise notice 'get_storage_at_by_number (% is NULL OR % != %), falling back to full check.', temp_header, temp_header, temp_canonical_header;
+        TRUNCATE tmp_tt_stg2;
+        -- There is a slim chance of a false negative, if there is a common state_path at a lower height than we picked above,
+        -- or a different one at the same height.  The disadvantage is that this is very uncommon, and the join on
+        -- STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH is quite expensive when there are a lot of candidate rows,
+        -- so we wish to avoid this more expensive check when possible.
+        INSERT INTO tmp_tt_stg2
+        SELECT STORAGE_CIDS.HEADER_ID,
+               STORAGE_CIDS.CID,
+               STORAGE_CIDS.MH_KEY,
+               STORAGE_CIDS.BLOCK_NUMBER,
+               STORAGE_CIDS.NODE_TYPE,
+               was_state_leaf_removed_by_number(
+                       stateLeafKey,
+                       blockNo
+                   ) AS STATE_LEAF_REMOVED
+        FROM ETH.STORAGE_CIDS
+                 INNER JOIN ETH.STATE_CIDS ON (
+                    STORAGE_CIDS.HEADER_ID = STATE_CIDS.HEADER_ID
+                AND STORAGE_CIDS.BLOCK_NUMBER = STATE_CIDS.BLOCK_NUMBER
+                AND STORAGE_CIDS.STATE_PATH = STATE_CIDS.STATE_PATH
+            )
+                 INNER JOIN ETH.HEADER_CIDS ON (
+                    STATE_CIDS.HEADER_ID = HEADER_CIDS.BLOCK_HASH
+                AND STATE_CIDS.BLOCK_NUMBER = HEADER_CIDS.BLOCK_NUMBER
+            )
+        WHERE STATE_LEAF_KEY = stateLeafKey
+          AND STATE_CIDS.BLOCK_NUMBER <= blockNo
+          AND STORAGE_LEAF_KEY = storageLeafKey
+          AND STORAGE_CIDS.BLOCK_NUMBER <= blockNo
+          AND HEADER_CIDS.BLOCK_NUMBER <= blockNo
+          AND HEADER_CIDS.BLOCK_HASH = (SELECT CANONICAL_HEADER_HASH(HEADER_CIDS.BLOCK_NUMBER))
+        ORDER BY HEADER_CIDS.BLOCK_NUMBER DESC
+        LIMIT 1;
+    END IF;
+
+
+    RETURN QUERY SELECT t.cid, t.mh_key, t.block_number, t.node_type, t.state_leaf_removed from tmp_tt_stg2 as t;
 END
 $$;
 

--- a/db/migrations/00023_get_storage_at_functions.sql
+++ b/db/migrations/00023_get_storage_at_functions.sql
@@ -11,7 +11,7 @@ ORDER BY state_cids.block_number DESC LIMIT 1;
 $$
 language sql;
 
-CREATE OR REPLACE FUNCTION public.test_get_storage_at_by_number(stateLeafKey text, storageLeafKey text, blockNo bigint)
+CREATE OR REPLACE FUNCTION public.get_storage_at_by_number(stateLeafKey text, storageLeafKey text, blockNo bigint)
     RETURNS TABLE
             (
                 cid                text,


### PR DESCRIPTION
Before:
```
# explain analyze select * from get_storage_at_by_hash('0x3a55e670852b2b985cd8c252fddae2acb4f798d0fecdcb1e2da53726332eb559', '0xceb09ad4b38c2b87567293b73d49fcdea74dadb2546fa8e55e157c9a302ed44f', '0x3a76d8d865efc3be160fc2fbb1925f36707b1a54daf5e61656e8cc0504797c7a');
                                                           QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------
 Function Scan on get_storage_at_by_hash  (cost=0.25..10.25 rows=1000 width=77) (actual time=1234.447..1234.448 rows=1 loops=1)
 Planning Time: 0.055 ms
 Execution Time: 1234.472 ms
(3 rows)


# select * from get_storage_at_by_hash('0x3a55e670852b2b985cd8c252fddae2acb4f798d0fecdcb1e2da53726332eb559', '0xceb09ad4b38c2b87567293b73d49fcdea74dadb2546fa8e55e157c9a302ed44f', '0x3a76d8d865efc3be160fc2fbb1925f36707b1a54daf5e61656e8cc0504797c7a');
                              cid                              |                             mh_key                              | block_number | node_type | state_leaf_removed
---------------------------------------------------------------+-----------------------------------------------------------------+--------------+-----------+--------------------
 bagmacgza5pdieleejyn74xbye7kbxo4c77ehtbbprhqajg7d5ov4iuhuef5a | /blocks/DMQOXRUCFSCE4G76LQ4CPVA3XOBP7SDZQQXYTYAETPR6XK6EKD2CC6Q |     12499699 |         2 | f
(1 row)

```

After:

```
# explain analyze select * from test_get_storage_at_by_hash('0x3a55e670852b2b985cd8c252fddae2acb4f798d0fecdcb1e2da53726332eb559', '0xceb09ad4b38c2b87567293b73d49fcdea74dadb2546fa8e55e157c9a302ed44f', '0x3a76d8d865efc3be160fc2fbb1925f36707b1a54daf5e61656e8cc0504797c7a');
                                                           QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------
 Function Scan on test_get_storage_at_by_hash  (cost=0.25..10.25 rows=1000 width=77) (actual time=95.012..95.013 rows=1 loops=1)
 Planning Time: 0.049 ms
 Execution Time: 95.036 ms
(3 rows)

# select * from test_get_storage_at_by_hash('0x3a55e670852b2b985cd8c252fddae2acb4f798d0fecdcb1e2da53726332eb559', '0xceb09ad4b38c2b87567293b73d49fcdea74dadb2546fa8e55e157c9a302ed44f', '0x3a76d8d865efc3be160fc2fbb1925f36707b1a54daf5e61656e8cc0504797c7a');
                              cid                              |                             mh_key                              | block_number | node_type | state_leaf_removed
---------------------------------------------------------------+-----------------------------------------------------------------+--------------+-----------+--------------------
 bagmacgza5pdieleejyn74xbye7kbxo4c77ehtbbprhqajg7d5ov4iuhuef5a | /blocks/DMQOXRUCFSCE4G76LQ4CPVA3XOBP7SDZQQXYTYAETPR6XK6EKD2CC6Q |     12499699 |         2 | f
(1 row)
```