### PR TITLE
v5 part 4

### DIFF
--- a/db/migrations/00001_create_ipfs_blocks_table.sql
+++ b/db/migrations/00001_create_ipfs_blocks_table.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS public.blocks (
     block_number BIGINT NOT NULL,
-    key TEXT NOT NULL,
+    cid TEXT NOT NULL,
     data BYTEA NOT NULL,
     PRIMARY KEY (key, block_number)
 );

--- a/db/migrations/00001_create_ipfs_blocks_table.sql
+++ b/db/migrations/00001_create_ipfs_blocks_table.sql
@@ -1,10 +1,13 @@
 -- +goose Up
-CREATE TABLE IF NOT EXISTS public.blocks (
+CREATE SCHEMA ipld;
+
+CREATE TABLE IF NOT EXISTS ipld.blocks (
     block_number BIGINT NOT NULL,
-    cid TEXT NOT NULL,
+    key TEXT NOT NULL,
     data BYTEA NOT NULL,
     PRIMARY KEY (key, block_number)
 );
 
 -- +goose Down
-DROP TABLE public.blocks;
+DROP TABLE ipld.blocks;
+DROP SCHEMA ipld;

--- a/db/migrations/00004_create_eth_header_cids_table.sql
+++ b/db/migrations/00004_create_eth_header_cids_table.sql
@@ -13,7 +13,6 @@ CREATE TABLE IF NOT EXISTS eth.header_cids (
     uncles_hash           VARCHAR(66) NOT NULL,
     bloom                 BYTEA NOT NULL,
     timestamp             BIGINT NOT NULL,
-    mh_key                TEXT NOT NULL,
     coinbase              VARCHAR(66) NOT NULL,
     PRIMARY KEY (block_hash, block_number)
 );

--- a/db/migrations/00005_create_eth_uncle_cids_table.sql
+++ b/db/migrations/00005_create_eth_uncle_cids_table.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS eth.uncle_cids (
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     reward                NUMERIC NOT NULL,
-    mh_key                TEXT NOT NULL,
     PRIMARY KEY (block_hash, block_number)
 );
 

--- a/db/migrations/00005_create_eth_uncle_cids_table.sql
+++ b/db/migrations/00005_create_eth_uncle_cids_table.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS eth.uncle_cids (
     parent_hash           VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
     reward                NUMERIC NOT NULL,
+    index                 INT NOT NULL,
     PRIMARY KEY (block_hash, block_number)
 );
 

--- a/db/migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/migrations/00006_create_eth_transaction_cids_table.sql
@@ -8,7 +8,6 @@ CREATE TABLE IF NOT EXISTS eth.transaction_cids (
     src                   VARCHAR(66) NOT NULL,
     index                 INTEGER NOT NULL,
     mh_key                TEXT NOT NULL,
-    tx_data               BYTEA,
     tx_type               INTEGER,
     value                 NUMERIC,
     PRIMARY KEY (tx_hash, header_id, block_number)

--- a/db/migrations/00006_create_eth_transaction_cids_table.sql
+++ b/db/migrations/00006_create_eth_transaction_cids_table.sql
@@ -7,7 +7,6 @@ CREATE TABLE IF NOT EXISTS eth.transaction_cids (
     dst                   VARCHAR(66),
     src                   VARCHAR(66) NOT NULL,
     index                 INTEGER NOT NULL,
-    mh_key                TEXT NOT NULL,
     tx_type               INTEGER,
     value                 NUMERIC,
     PRIMARY KEY (tx_hash, header_id, block_number)

--- a/db/migrations/00007_create_eth_receipt_cids_table.sql
+++ b/db/migrations/00007_create_eth_receipt_cids_table.sql
@@ -3,13 +3,12 @@ CREATE TABLE IF NOT EXISTS eth.receipt_cids (
     block_number          BIGINT NOT NULL,
     header_id             VARCHAR(66) NOT NULL,
     tx_id                 VARCHAR(66) NOT NULL,
-    leaf_cid              TEXT NOT NULL,
+    cid                   TEXT NOT NULL,
     contract              VARCHAR(66),
     contract_hash         VARCHAR(66),
-    leaf_mh_key           TEXT NOT NULL,
+    mh_key                TEXT NOT NULL,
     post_state            VARCHAR(66),
     post_status           SMALLINT,
-    log_root              VARCHAR(66),
     PRIMARY KEY (tx_id, header_id, block_number)
 );
 

--- a/db/migrations/00007_create_eth_receipt_cids_table.sql
+++ b/db/migrations/00007_create_eth_receipt_cids_table.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS eth.receipt_cids (
     cid                   TEXT NOT NULL,
     contract              VARCHAR(66),
     contract_hash         VARCHAR(66),
-    mh_key                TEXT NOT NULL,
     post_state            VARCHAR(66),
     post_status           SMALLINT,
     PRIMARY KEY (tx_id, header_id, block_number)

--- a/db/migrations/00008_create_eth_state_cids_table.sql
+++ b/db/migrations/00008_create_eth_state_cids_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS eth.state_cids (
     header_id             VARCHAR(66) NOT NULL,
     state_leaf_key        VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
-    state_path            BYTEA NOT NULL,
+    partial_path          BYTEA NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
     mh_key                TEXT NOT NULL,
     balance               NUMERIC,      -- NULL if "removed"

--- a/db/migrations/00008_create_eth_state_cids_table.sql
+++ b/db/migrations/00008_create_eth_state_cids_table.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS eth.state_cids (
     cid                   TEXT NOT NULL,
     partial_path          BYTEA NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
-    mh_key                TEXT NOT NULL,
     balance               NUMERIC,      -- NULL if "removed"
     nonce                 BIGINT,       -- NULL if "removed"
     code_hash             VARCHAR(66),  -- NULL if "removed"

--- a/db/migrations/00009_create_eth_storage_cids_table.sql
+++ b/db/migrations/00009_create_eth_storage_cids_table.sql
@@ -7,7 +7,6 @@ CREATE TABLE IF NOT EXISTS eth.storage_cids (
     cid                   TEXT NOT NULL,
     partial_path          BYTEA NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
-    mh_key                TEXT NOT NULL,
     val                   BYTEA,  -- NULL if "removed"
     removed               BOOLEAN NOT NULL,
     PRIMARY KEY (storage_leaf_key, state_leaf_key, header_id, block_number)

--- a/db/migrations/00009_create_eth_storage_cids_table.sql
+++ b/db/migrations/00009_create_eth_storage_cids_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS eth.storage_cids (
     state_leaf_key        VARCHAR(66) NOT NULL,
     storage_leaf_key      VARCHAR(66) NOT NULL,
     cid                   TEXT NOT NULL,
-    storage_path          BYTEA NOT NULL,
+    partial_path          BYTEA NOT NULL,
     diff                  BOOLEAN NOT NULL DEFAULT FALSE,
     mh_key                TEXT NOT NULL,
     val                   BYTEA,  -- NULL if "removed"

--- a/db/migrations/00011_create_eth_log_cids_table.sql
+++ b/db/migrations/00011_create_eth_log_cids_table.sql
@@ -3,7 +3,6 @@ CREATE TABLE IF NOT EXISTS eth.log_cids (
     block_number        BIGINT NOT NULL,
     header_id           VARCHAR(66) NOT NULL,
     cid                 TEXT NOT NULL,
-    mh_key              TEXT NOT NULL,
     rct_id              VARCHAR(66) NOT NULL,
     address             VARCHAR(66) NOT NULL,
     index               INTEGER NOT NULL,

--- a/db/migrations/00011_create_eth_log_cids_table.sql
+++ b/db/migrations/00011_create_eth_log_cids_table.sql
@@ -2,8 +2,8 @@
 CREATE TABLE IF NOT EXISTS eth.log_cids (
     block_number        BIGINT NOT NULL,
     header_id           VARCHAR(66) NOT NULL,
-    leaf_cid            TEXT NOT NULL,
-    leaf_mh_key         TEXT NOT NULL,
+    cid                 TEXT NOT NULL,
+    mh_key              TEXT NOT NULL,
     rct_id              VARCHAR(66) NOT NULL,
     address             VARCHAR(66) NOT NULL,
     index               INTEGER NOT NULL,

--- a/db/migrations/00011_create_eth_log_cids_table.sql
+++ b/db/migrations/00011_create_eth_log_cids_table.sql
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS eth.log_cids (
     topic1              VARCHAR(66),
     topic2              VARCHAR(66),
     topic3              VARCHAR(66),
-    log_data            BYTEA,
     PRIMARY KEY (rct_id, index, header_id, block_number)
 );
 

--- a/db/migrations/00013_create_pending_tables.sql
+++ b/db/migrations/00013_create_pending_tables.sql
@@ -5,9 +5,17 @@
 -- instead, what we are doing for the time being is embedding the RLP here
 CREATE TABLE IF NOT EXISTS eth.pending_txs (
     tx_hash               VARCHAR(66) NOT NULL PRIMARY KEY,
+    block_hash            VARCHAR(66) NOT NULL, -- references block_hash in pending_blocks for the pending block this tx belongs to
     timestamp             BIGINT NOT NULL,
     raw                   BYTEA NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS eth.pending_blocks (
+    block_hash VARCHAR(66) NOT NULL PRIMARY KEY,
+    block_number BIGINT NOT NULL,
+    raw_header BYTEA NOT NULL
+)
+
 -- +goose Down
+DROP TABLE eth.pending_blocks;
 DROP TABLE eth.pending_txs;

--- a/db/migrations/00013_create_pending_tx_table.sql
+++ b/db/migrations/00013_create_pending_tx_table.sql
@@ -5,6 +5,7 @@
 -- instead, what we are doing for the time being is embedding the RLP here
 CREATE TABLE IF NOT EXISTS eth.pending_txs (
     tx_hash               VARCHAR(66) NOT NULL PRIMARY KEY,
+    timestamp             BIGINT NOT NULL,
     raw                   BYTEA NOT NULL
 );
 

--- a/db/migrations/00013_create_pending_tx_table.sql
+++ b/db/migrations/00013_create_pending_tx_table.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- pending tx isn't tightly associated with a block height, so we can't insert the RLP encoded tx as an IPLD block
--- in public.blocks since it is denormalized by block number (we could do something hacky like using head height
+-- in ipld.blocks since it is denormalized by block number (we could do something hacky like using head height
 -- when the block was seen, or 0 or -1 or something)
 -- instead, what we are doing for the time being is embedding the RLP here
 CREATE TABLE IF NOT EXISTS eth.pending_txs (

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -1,36 +1,32 @@
 -- +goose Up
 -- header indexes
 CREATE INDEX header_block_number_index ON eth.header_cids USING brin (block_number);
-CREATE UNIQUE INDEX header_cid_index ON eth.header_cids USING btree (cid, block_number);
-CREATE UNIQUE INDEX header_mh_block_number_index ON eth.header_cids USING btree (mh_key, block_number);
+CREATE UNIQUE INDEX header_cid_block_number_index ON eth.header_cids USING btree (cid, block_number);
 CREATE INDEX state_root_index ON eth.header_cids USING btree (state_root);
 CREATE INDEX timestamp_index ON eth.header_cids USING brin (timestamp);
 
 -- uncle indexes
 CREATE INDEX uncle_block_number_index ON eth.uncle_cids USING brin (block_number);
-CREATE UNIQUE INDEX uncle_mh_block_number_index ON eth.uncle_cids USING btree (mh_key, block_number);
+CREATE UNIQUE INDEX uncle_cid_block_number_index ON eth.uncle_cids USING btree (cid, block_number);
 CREATE INDEX uncle_header_id_index ON eth.uncle_cids USING btree (header_id);
 
 -- transaction indexes
 CREATE INDEX tx_block_number_index ON eth.transaction_cids USING brin (block_number);
 CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
-CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number);
-CREATE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
+CREATE INDEX tx_cid_block_number_index ON eth.transaction_cids USING btree (cid, block_number);
 CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
 CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 
 -- receipt indexes
 CREATE INDEX rct_block_number_index ON eth.receipt_cids USING brin (block_number);
 CREATE INDEX rct_header_id_index ON eth.receipt_cids USING btree (header_id);
-CREATE INDEX rct_cid_index ON eth.receipt_cids USING btree (cid);
-CREATE INDEX rct_mh_block_number_index ON eth.receipt_cids USING btree (mh_key, block_number);
+CREATE INDEX rct_cid_block_number_index ON eth.receipt_cids USING btree (cid, block_number);
 CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
 CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_hash);
 
 -- state node indexes
 CREATE INDEX state_block_number_index ON eth.state_cids USING brin (block_number);
-CREATE INDEX state_cid_index ON eth.state_cids USING btree (cid);
-CREATE INDEX state_mh_block_number_index ON eth.state_cids USING btree (mh_key, block_number);
+CREATE INDEX state_cid_block_number_index ON eth.state_cids USING btree (cid, block_number);
 CREATE INDEX state_header_id_index ON eth.state_cids USING btree (header_id);
 CREATE INDEX state_path_index ON eth.state_cids USING btree (state_path);
 CREATE INDEX state_removed_index ON eth.state_cids USING btree (removed);
@@ -40,8 +36,7 @@ CREATE INDEX state_leaf_key_block_number_index ON eth.state_cids(state_leaf_key,
 -- storage node indexes
 CREATE INDEX storage_block_number_index ON eth.storage_cids USING brin (block_number);
 CREATE INDEX storage_state_leaf_key_index ON eth.storage_cids USING btree (state_leaf_key);
-CREATE INDEX storage_cid_index ON eth.storage_cids USING btree (cid);
-CREATE INDEX storage_mh_block_number_index ON eth.storage_cids USING btree (mh_key, block_number);
+CREATE INDEX storage_cid_block_number_index ON eth.storage_cids USING btree (cid, block_number);
 CREATE INDEX storage_header_id_index ON eth.storage_cids USING btree (header_id);
 CREATE INDEX storage_path_index ON eth.storage_cids USING btree (storage_path);
 CREATE INDEX storage_removed_index ON eth.storage_cids USING btree (removed);
@@ -55,8 +50,7 @@ CREATE INDEX access_list_storage_keys_index ON eth.access_list_elements USING gi
 -- log indexes
 CREATE INDEX log_block_number_index ON eth.log_cids USING brin (block_number);
 CREATE INDEX log_header_id_index ON eth.log_cids USING btree (header_id);
-CREATE INDEX log_mh_block_number_index ON eth.log_cids USING btree (mh_key, block_number);
-CREATE INDEX log_cid_index ON  eth.log_cids USING btree (cid);
+CREATE INDEX log_cid_block_number_index ON eth.log_cids USING btree (cid, block_number);
 CREATE INDEX log_address_index ON eth.log_cids USING btree (address);
 CREATE INDEX log_topic0_index ON eth.log_cids USING btree (topic0);
 CREATE INDEX log_topic1_index ON eth.log_cids USING btree (topic1);
@@ -70,8 +64,7 @@ DROP INDEX eth.log_topic2_index;
 DROP INDEX eth.log_topic1_index;
 DROP INDEX eth.log_topic0_index;
 DROP INDEX eth.log_address_index;
-DROP INDEX eth.log_cid_index;
-DROP INDEX eth.log_mh_block_number_index;
+DROP INDEX eth.log_cid_block_number_index;
 DROP INDEX eth.log_header_id_index;
 DROP INDEX eth.log_block_number_index;
 
@@ -84,8 +77,7 @@ DROP INDEX eth.access_list_block_number_index;
 DROP INDEX eth.storage_removed_index;
 DROP INDEX eth.storage_path_index;
 DROP INDEX eth.storage_header_id_index;
-DROP INDEX eth.storage_mh_block_number_index;
-DROP INDEX eth.storage_cid_index;
+DROP INDEX eth.storage_cid_block_number_index;
 DROP INDEX eth.storage_leaf_key_index;
 DROP INDEX eth.storage_state_leaf_key_index;
 DROP INDEX eth.storage_block_number_index;
@@ -96,35 +88,31 @@ DROP INDEX eth.state_code_hash_index;
 DROP INDEX eth.state_removed_index;
 DROP INDEX eth.state_path_index;
 DROP INDEX eth.state_header_id_index;
-DROP INDEX eth.state_mh_block_number_index;
-DROP INDEX eth.state_cid_index;
+DROP INDEX eth.state_cid_block_number_index;
 DROP INDEX eth.state_block_number_index;
 DROP INDEX eth.state_leaf_key_block_number_index;
 
 -- receipt indexes
 DROP INDEX eth.rct_contract_hash_index;
 DROP INDEX eth.rct_contract_index;
-DROP INDEX eth.rct_mh_block_number_index;
-DROP INDEX eth.rct_cid_index;
+DROP INDEX eth.rct_cid_block_number_index;
 DROP INDEX eth.rct_header_id_index;
 DROP INDEX eth.rct_block_number_index;
 
 -- transaction indexes
 DROP INDEX eth.tx_src_index;
 DROP INDEX eth.tx_dst_index;
-DROP INDEX eth.tx_mh_block_number_index;
-DROP INDEX eth.tx_cid_index;
+DROP INDEX eth.tx_cid_block_number_index;
 DROP INDEX eth.tx_header_id_index;
 DROP INDEX eth.tx_block_number_index;
 
 -- uncle indexes
 DROP INDEX eth.uncle_block_number_index;
-DROP INDEX eth.uncle_mh_block_number_index;
+DROP INDEX eth.uncle_cid_block_number_index;
 DROP INDEX eth.uncle_header_id_index;
 
 -- header indexes
 DROP INDEX eth.timestamp_index;
 DROP INDEX eth.state_root_index;
-DROP INDEX eth.header_mh_block_number_index;
-DROP INDEX eth.header_cid_index;
+DROP INDEX eth.header_cid_block_number_index;
 DROP INDEX eth.header_block_number_index;

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -28,7 +28,7 @@ CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_h
 CREATE INDEX state_block_number_index ON eth.state_cids USING brin (block_number);
 CREATE INDEX state_cid_block_number_index ON eth.state_cids USING btree (cid, block_number);
 CREATE INDEX state_header_id_index ON eth.state_cids USING btree (header_id);
-CREATE INDEX state_path_index ON eth.state_cids USING btree (state_path);
+CREATE INDEX state_partial_path_index ON eth.state_cids USING btree (partial_path);
 CREATE INDEX state_removed_index ON eth.state_cids USING btree (removed);
 CREATE INDEX state_code_hash_index ON eth.state_cids USING btree (code_hash); -- could be useful for e.g. selecting all the state accounts with the same contract bytecode deployed
 CREATE INDEX state_leaf_key_block_number_index ON eth.state_cids(state_leaf_key, block_number DESC);
@@ -38,7 +38,7 @@ CREATE INDEX storage_block_number_index ON eth.storage_cids USING brin (block_nu
 CREATE INDEX storage_state_leaf_key_index ON eth.storage_cids USING btree (state_leaf_key);
 CREATE INDEX storage_cid_block_number_index ON eth.storage_cids USING btree (cid, block_number);
 CREATE INDEX storage_header_id_index ON eth.storage_cids USING btree (header_id);
-CREATE INDEX storage_path_index ON eth.storage_cids USING btree (storage_path);
+CREATE INDEX storage_partial_path_index ON eth.storage_cids USING btree (partial_path);
 CREATE INDEX storage_removed_index ON eth.storage_cids USING btree (removed);
 CREATE INDEX storage_leaf_key_block_number_index ON eth.storage_cids(storage_leaf_key, block_number DESC);
 
@@ -75,7 +75,7 @@ DROP INDEX eth.access_list_block_number_index;
 
 -- storage node indexes
 DROP INDEX eth.storage_removed_index;
-DROP INDEX eth.storage_path_index;
+DROP INDEX eth.storage_partial_path_index;
 DROP INDEX eth.storage_header_id_index;
 DROP INDEX eth.storage_cid_block_number_index;
 DROP INDEX eth.storage_leaf_key_index;
@@ -86,7 +86,7 @@ DROP INDEX eth.storage_leaf_key_block_number_index;
 -- state node indexes
 DROP INDEX eth.state_code_hash_index;
 DROP INDEX eth.state_removed_index;
-DROP INDEX eth.state_path_index;
+DROP INDEX eth.state_partial_path_index;
 DROP INDEX eth.state_header_id_index;
 DROP INDEX eth.state_cid_block_number_index;
 DROP INDEX eth.state_block_number_index;

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -23,8 +23,8 @@ CREATE INDEX tx_data_index ON eth.transaction_cids USING btree (tx_data);
 -- receipt indexes
 CREATE INDEX rct_block_number_index ON eth.receipt_cids USING brin (block_number);
 CREATE INDEX rct_header_id_index ON eth.receipt_cids USING btree (header_id);
-CREATE INDEX rct_leaf_cid_index ON eth.receipt_cids USING btree (leaf_cid);
-CREATE INDEX rct_leaf_mh_block_number_index ON eth.receipt_cids USING btree (leaf_mh_key, block_number);
+CREATE INDEX rct_cid_index ON eth.receipt_cids USING btree (cid);
+CREATE INDEX rct_mh_block_number_index ON eth.receipt_cids USING btree (mh_key, block_number);
 CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
 CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_hash);
 
@@ -56,8 +56,8 @@ CREATE INDEX access_list_storage_keys_index ON eth.access_list_elements USING gi
 -- log indexes
 CREATE INDEX log_block_number_index ON eth.log_cids USING brin (block_number);
 CREATE INDEX log_header_id_index ON eth.log_cids USING btree (header_id);
-CREATE INDEX log_leaf_mh_block_number_index ON eth.log_cids USING btree (leaf_mh_key, block_number);
-CREATE INDEX log_cid_index ON  eth.log_cids USING btree (leaf_cid);
+CREATE INDEX log_mh_block_number_index ON eth.log_cids USING btree (mh_key, block_number);
+CREATE INDEX log_cid_index ON  eth.log_cids USING btree (cid);
 CREATE INDEX log_address_index ON eth.log_cids USING btree (address);
 CREATE INDEX log_topic0_index ON eth.log_cids USING btree (topic0);
 CREATE INDEX log_topic1_index ON eth.log_cids USING btree (topic1);
@@ -74,7 +74,7 @@ DROP INDEX eth.log_topic1_index;
 DROP INDEX eth.log_topic0_index;
 DROP INDEX eth.log_address_index;
 DROP INDEX eth.log_cid_index;
-DROP INDEX eth.log_leaf_mh_block_number_index;
+DROP INDEX eth.log_mh_block_number_index;
 DROP INDEX eth.log_header_id_index;
 DROP INDEX eth.log_block_number_index;
 
@@ -107,8 +107,8 @@ DROP INDEX eth.state_leaf_key_block_number_index;
 -- receipt indexes
 DROP INDEX eth.rct_contract_hash_index;
 DROP INDEX eth.rct_contract_index;
-DROP INDEX eth.rct_leaf_mh_block_number_index;
-DROP INDEX eth.rct_leaf_cid_index;
+DROP INDEX eth.rct_mh_block_number_index;
+DROP INDEX eth.rct_cid_index;
 DROP INDEX eth.rct_header_id_index;
 DROP INDEX eth.rct_block_number_index;
 

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -18,7 +18,6 @@ CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid, block_number
 CREATE INDEX tx_mh_block_number_index ON eth.transaction_cids USING btree (mh_key, block_number);
 CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
 CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
-CREATE INDEX tx_data_index ON eth.transaction_cids USING btree (tx_data);
 
 -- receipt indexes
 CREATE INDEX rct_block_number_index ON eth.receipt_cids USING brin (block_number);
@@ -63,11 +62,9 @@ CREATE INDEX log_topic0_index ON eth.log_cids USING btree (topic0);
 CREATE INDEX log_topic1_index ON eth.log_cids USING btree (topic1);
 CREATE INDEX log_topic2_index ON eth.log_cids USING btree (topic2);
 CREATE INDEX log_topic3_index ON eth.log_cids USING btree (topic3);
-CREATE INDEX log_data_index ON eth.log_cids USING btree (log_data);
 
 -- +goose Down
 -- log indexes
-DROP INDEX eth.log_data_index;
 DROP INDEX eth.log_topic3_index;
 DROP INDEX eth.log_topic2_index;
 DROP INDEX eth.log_topic1_index;
@@ -113,7 +110,6 @@ DROP INDEX eth.rct_header_id_index;
 DROP INDEX eth.rct_block_number_index;
 
 -- transaction indexes
-DROP INDEX eth.tx_data_index;
 DROP INDEX eth.tx_src_index;
 DROP INDEX eth.tx_dst_index;
 DROP INDEX eth.tx_mh_block_number_index;

--- a/db/migrations/00019_convert_to_hypertables.sql
+++ b/db/migrations/00019_convert_to_hypertables.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-SELECT create_hypertable('public.blocks', 'block_number', migrate_data => true, chunk_time_interval => 32768);
+SELECT create_hypertable('ipld.blocks', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.header_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.uncle_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.transaction_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
@@ -27,7 +27,7 @@ CREATE TABLE eth.receipt_cids_i (LIKE eth.receipt_cids INCLUDING ALL);
 CREATE TABLE eth.transaction_cids_i (LIKE eth.transaction_cids INCLUDING ALL);
 CREATE TABLE eth.uncle_cids_i (LIKE eth.uncle_cids INCLUDING ALL);
 CREATE TABLE eth.header_cids_i (LIKE eth.header_cids INCLUDING ALL);
-CREATE TABLE public.blocks_i (LIKE public.blocks INCLUDING ALL);
+CREATE TABLE ipld.blocks_i (LIKE ipld.blocks INCLUDING ALL);
 
 -- migrate data
 INSERT INTO eth.log_cids_i (SELECT * FROM eth.log_cids);
@@ -38,7 +38,7 @@ INSERT INTO eth.receipt_cids_i (SELECT * FROM eth.receipt_cids);
 INSERT INTO eth.transaction_cids_i (SELECT * FROM eth.transaction_cids);
 INSERT INTO eth.uncle_cids_i (SELECT * FROM eth.uncle_cids);
 INSERT INTO eth.header_cids_i (SELECT * FROM eth.header_cids);
-INSERT INTO public.blocks_i (SELECT * FROM public.blocks);
+INSERT INTO ipld.blocks_i (SELECT * FROM ipld.blocks);
 
 -- drop hypertables
 DROP TABLE eth.log_cids;
@@ -49,7 +49,7 @@ DROP TABLE eth.receipt_cids;
 DROP TABLE eth.transaction_cids;
 DROP TABLE eth.uncle_cids;
 DROP TABLE eth.header_cids;
-DROP TABLE public.blocks;
+DROP TABLE ipld.blocks;
 
 -- rename new tables
 ALTER TABLE eth.log_cids_i RENAME TO log_cids;
@@ -60,4 +60,4 @@ ALTER TABLE eth.receipt_cids_i RENAME TO receipt_cids;
 ALTER TABLE eth.transaction_cids_i RENAME TO transaction_cids;
 ALTER TABLE eth.uncle_cids_i RENAME TO uncle_cids;
 ALTER TABLE eth.header_cids_i RENAME TO header_cids;
-ALTER TABLE public.blocks_i RENAME TO blocks;
+ALTER TABLE ipld.blocks_i RENAME TO blocks;

--- a/schema.sql
+++ b/schema.sql
@@ -338,6 +338,7 @@ CREATE TABLE eth.log_cids (
 
 CREATE TABLE eth.pending_txs (
     tx_hash character varying(66) NOT NULL,
+    block_hash character varying(66) NOT NULL,
     "timestamp" bigint NOT NULL,
     raw bytea NOT NULL
 );
@@ -429,7 +430,8 @@ CREATE TABLE eth.uncle_cids (
     header_id character varying(66) NOT NULL,
     parent_hash character varying(66) NOT NULL,
     cid text NOT NULL,
-    reward numeric NOT NULL
+    reward numeric NOT NULL,
+    index integer NOT NULL
 );
 
 


### PR DESCRIPTION
Contains the updates described in #122 
* Decided to use `cid` instead of `mh_key` because the [CAR format](https://ipld.io/specs/transport/car/carv1/#cid) used in [Filecoin deals](https://spec.filecoin.io/systems/filecoin_files/piece/) uses `cid:bytes` pairs.
* Tentatively dropped `log_cids.log_data` and `transaction_cids.tx_data`; data can still be accessed in IPLD block referenced by `cid` in `ipld.blocks`.
* Also renamed `public.blocks` to `ipld.blocks` since this table has already deviated from the format expected in https://github.com/ipfs/go-ds-sql and this provides more clarity to the overloaded "block" term. 