### PR TITLE
Schema fixes for v5

### DIFF
--- a/db/migrations/00012_create_cid_indexes.sql
+++ b/db/migrations/00012_create_cid_indexes.sql
@@ -7,7 +7,7 @@ CREATE INDEX timestamp_index ON eth.header_cids USING btree (timestamp);
 
 -- uncle indexes
 CREATE INDEX uncle_block_number_index ON eth.uncle_cids USING btree (block_number);
-CREATE UNIQUE INDEX uncle_cid_block_number_index ON eth.uncle_cids USING btree (cid, block_number);
+CREATE UNIQUE INDEX uncle_cid_block_number_index ON eth.uncle_cids USING btree (cid, block_number, index);
 CREATE INDEX uncle_header_id_index ON eth.uncle_cids USING btree (header_id);
 
 -- transaction indexes


### PR DESCRIPTION
* Adds `index` column to unique index of `eth.uncle_cids` to disambiguate uncles (since CID is now computed from the combined list of headers)
* Breaks the dependency of stored functions on `eth.header_cids` table using a new composite interface type - partial fix for https://github.com/cerc-io/ipld-eth-db/issues/133