### PR TITLE
Keep eth.header_cids as a standard table, not hypertable.

### DIFF
--- a/db/migrations/00018_convert_to_hypertables.sql
+++ b/db/migrations/00018_convert_to_hypertables.sql
@@ -1,6 +1,5 @@
 -- +goose Up
 SELECT create_hypertable('ipld.blocks', 'block_number', migrate_data => true, chunk_time_interval => 32768);
-SELECT create_hypertable('eth.header_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.uncle_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.transaction_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
 SELECT create_hypertable('eth.receipt_cids', 'block_number', migrate_data => true, chunk_time_interval => 32768);
@@ -24,7 +23,6 @@ CREATE TABLE eth.state_cids_i (LIKE eth.state_cids INCLUDING ALL);
 CREATE TABLE eth.receipt_cids_i (LIKE eth.receipt_cids INCLUDING ALL);
 CREATE TABLE eth.transaction_cids_i (LIKE eth.transaction_cids INCLUDING ALL);
 CREATE TABLE eth.uncle_cids_i (LIKE eth.uncle_cids INCLUDING ALL);
-CREATE TABLE eth.header_cids_i (LIKE eth.header_cids INCLUDING ALL);
 CREATE TABLE ipld.blocks_i (LIKE ipld.blocks INCLUDING ALL);
 
 -- migrate data
@@ -34,7 +32,6 @@ INSERT INTO eth.state_cids_i (SELECT * FROM eth.state_cids);
 INSERT INTO eth.receipt_cids_i (SELECT * FROM eth.receipt_cids);
 INSERT INTO eth.transaction_cids_i (SELECT * FROM eth.transaction_cids);
 INSERT INTO eth.uncle_cids_i (SELECT * FROM eth.uncle_cids);
-INSERT INTO eth.header_cids_i (SELECT * FROM eth.header_cids);
 INSERT INTO ipld.blocks_i (SELECT * FROM ipld.blocks);
 
 -- drop hypertables
@@ -44,7 +41,6 @@ DROP TABLE eth.state_cids;
 DROP TABLE eth.receipt_cids;
 DROP TABLE eth.transaction_cids;
 DROP TABLE eth.uncle_cids;
-DROP TABLE eth.header_cids;
 DROP TABLE ipld.blocks;
 
 -- rename new tables
@@ -54,5 +50,4 @@ ALTER TABLE eth.state_cids_i RENAME TO state_cids;
 ALTER TABLE eth.receipt_cids_i RENAME TO receipt_cids;
 ALTER TABLE eth.transaction_cids_i RENAME TO transaction_cids;
 ALTER TABLE eth.uncle_cids_i RENAME TO uncle_cids;
-ALTER TABLE eth.header_cids_i RENAME TO header_cids;
 ALTER TABLE ipld.blocks_i RENAME TO blocks;

--- a/schema.sql
+++ b/schema.sql
@@ -857,13 +857,6 @@ CREATE INDEX blocks_block_number_idx ON ipld.blocks USING btree (block_number DE
 
 
 --
--- Name: header_cids ts_insert_blocker; Type: TRIGGER; Schema: eth; Owner: -
---
-
-CREATE TRIGGER ts_insert_blocker BEFORE INSERT ON eth.header_cids FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker();
-
-
---
 -- Name: log_cids ts_insert_blocker; Type: TRIGGER; Schema: eth; Owner: -
 --
 


### PR DESCRIPTION
Anytime we need to lookup by block hash, we join on the eth.header_cids table.  However, if the table is partitioned by block_number, we make looking up by hash less efficient, since we also partition the index and need to check each one.

As this is by far the smallest major table (1 row per block, averaging about 1KB per row), the need for partitioning is already doubtful.  Combined with slower lookups by hash, the performance impact tips negative rather than positive.