### PR TITLE
Fix typo in CI image build, simplify step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,8 @@ jobs:
       - id: vars
         name: Output SHA and version tag
         run: |
-          echo sha=$(echo ${GITHUB_SHA:0:7}) >> "$GITHUB_OUTPUT"
-          echo tag=$(echo ${GITHUB_REF#refs/tags/}) >> "$GITHUB_OUTPUT""
+          echo "sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: Build and tag image
         run: |
           docker build . \


### PR DESCRIPTION
Same typo as https://github.com/cerc-io/ipld-eth-server/pull/254 due to boneheaded copy-pasting.